### PR TITLE
fix: updated peerDependencies in package.json to support maplibre v2 to v4 since terra-draw is supporting maplibre from v2

### DIFF
--- a/.changeset/stupid-rings-listen.md
+++ b/.changeset/stupid-rings-listen.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: updated peerDependencies in package.json to support maplibre v2 to v4 since terra-draw is supporting maplibre from v2

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"vite": "^5.4.3"
 	},
 	"peerDependencies": {
-		"maplibre-gl": "^4.6.0",
+		"maplibre-gl": "^2.0.0 || ^3.0.0 || ^4.0.0",
 		"terra-draw": "^1.0.0-beta.1"
 	},
 	"repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       maplibre-gl:
-        specifier: ^4.6.0
+        specifier: ^2.0.0 || ^3.0.0 || ^4.0.0
         version: 4.6.0
       terra-draw:
         specifier: ^1.0.0-beta.1


### PR DESCRIPTION
related to #10