### PR TITLE
fix: merge modeOptions param into the first argument of constructor to make the interface simple.

### DIFF
--- a/.changeset/proud-dogs-grow.md
+++ b/.changeset/proud-dogs-grow.md
@@ -1,0 +1,36 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: merge modeOptions param into the first argument of constructor to make the interface simple.
+
+In v0.1.0, it used the second argument of constructor to customise drawing options for each Terra Draw mode. The second argment was now merged into the first argument as shown in the below sample code.
+
+```js
+const drawControl = new MaplibreTerradrawControl({
+	// only show polgyon, line and select mode.
+	modes: ['polygon', 'linestring', 'select'],
+	modeOptions: {
+		select: new TerraDrawSelectMode({
+			flags: {
+				// only update polygon settings for select mode.
+				// default settings will be used for other geometry types
+				// in this case, line uses default options of the plugin.
+				polygon: {
+					feature: {
+						draggable: false, // users cannot drag to move polygon
+						rotateable: true,
+						scaleable: true,
+						coordinates: {
+							midpoints: false, // users cannot add a node on the middle of edge.
+							draggable: true,
+							deletable: false // users cannot delete a node.
+						}
+					}
+				}
+			}
+		})
+	}
+});
+map.addControl(drawControl, 'top-left');
+```

--- a/src/lib/MaplibreTerradrawControl.ts
+++ b/src/lib/MaplibreTerradrawControl.ts
@@ -54,9 +54,15 @@ export class MaplibreTerradrawControl implements IControl {
 					// overwrite other select mode settings if new option does not contain.
 					const defaultOption = defaultOptions[m];
 					if (defaultOption) {
+						// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+						// @ts-ignore
 						const flags = defaultOption.flags;
 						Object.keys(flags).forEach((key) => {
+							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+							// @ts-ignore
 							if (newOption.flags[key]) return;
+							// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+							// @ts-ignore
 							newOption.flags[key] = flags[key];
 						});
 					}

--- a/src/lib/MaplibreTerradrawControl.ts
+++ b/src/lib/MaplibreTerradrawControl.ts
@@ -1,11 +1,6 @@
 import type { ControlPosition, IControl, Map } from 'maplibre-gl';
 import { TerraDraw, TerraDrawMapLibreGLAdapter } from 'terra-draw';
-import type {
-	ControlOptions,
-	ModeOptions,
-	TerradrawMode,
-	TerradrawModeClass
-} from './interfaces/index.js';
+import type { ControlOptions, TerradrawMode, TerradrawModeClass } from './interfaces/index.js';
 import { defaultControlOptions } from './constants/defaultControlOptions.js';
 import { getDefaultModeOptions } from './constants/getDefaultModeOptions.js';
 
@@ -24,23 +19,17 @@ export class MaplibreTerradrawControl implements IControl {
 	private terradraw?: TerraDraw;
 	private options: ControlOptions = defaultControlOptions;
 
-	private modeOptions?: ModeOptions;
-
 	/**
 	 * Constructor
 	 * @param options Plugin control options
-	 * @param modeOptions Overwrite Terra Draw mode options if you specified.
-	 *
 	 */
-	constructor(options?: ControlOptions, modeOptions?: ModeOptions) {
+	constructor(options?: ControlOptions) {
 		this.modeButtons = {};
 		this.activeMode = 'render';
 
 		if (options) {
 			this.options = Object.assign(this.options, options);
 		}
-
-		this.modeOptions = modeOptions;
 	}
 
 	public getDefaultPosition(): ControlPosition {
@@ -58,8 +47,21 @@ export class MaplibreTerradrawControl implements IControl {
 		const modes: TerradrawModeClass[] = [defaultOptions['render']];
 
 		this.options?.modes?.forEach((m) => {
-			if (this.modeOptions && this.modeOptions[m]) {
-				modes.push(this.modeOptions[m]);
+			if (this.options.modeOptions && this.options.modeOptions[m]) {
+				const newOption = this.options.modeOptions[m];
+
+				if (m === 'select') {
+					// overwrite other select mode settings if new option does not contain.
+					const defaultOption = defaultOptions[m];
+					if (defaultOption) {
+						const flags = defaultOption.flags;
+						Object.keys(flags).forEach((key) => {
+							if (newOption.flags[key]) return;
+							newOption.flags[key] = flags[key];
+						});
+					}
+				}
+				modes.push(newOption);
 			} else if (defaultOptions[m]) {
 				modes.push(defaultOptions[m]);
 			}

--- a/src/lib/interfaces/ControlOptions.ts
+++ b/src/lib/interfaces/ControlOptions.ts
@@ -1,3 +1,4 @@
+import type { ModeOptions } from './ModeOptions.js';
 import type { TerradrawMode } from './TerradrawMode.js';
 
 /**
@@ -17,4 +18,9 @@ export interface ControlOptions {
 	 * Open editor as default if true. Default is false
 	 */
 	open?: boolean;
+
+	/**
+	 * Overwrite Terra Draw mode options if you specified.
+	 */
+	modeOptions?: ModeOptions;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -159,15 +159,14 @@ map.addControl(drawControl, 'top-left');
 			lineNumbers
 			code={`
 const drawControl = new MaplibreTerradrawControl({
-	modes: [
-		'polygon',
-		'select'
-	],
+	// only show polgyon, line and select mode.
+	modes: ['polygon', 'linestring', 'select'],
 	modeOptions: {
 		select: new TerraDrawSelectMode({
 			flags: {
 				// only update polygon settings for select mode.
 				// default settings will be used for other geometry types
+				// in this case, line uses default options of the plugin.
 				polygon: {
 					feature: {
 						draggable: false, // users cannot drag to move polygon

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -162,24 +162,27 @@ const drawControl = new MaplibreTerradrawControl({
 	modes: [
 		'polygon',
 		'select'
-	]
-},{
-    select: new TerraDrawSelectMode({
-        flags: {
-            polygon: {
-                feature: {
-                    draggable: false, // users cannot drag to move polygon
-                    rotateable: true,
-                    scaleable: true,
-                    coordinates: {
-                        midpoints: false, // users cannot add a node on the middle of edge.
-                        draggable: true,
-                        deletable: false // users cannot delete a node.
-                    }
-                }
-            },
-        }
-    })
+	],
+	modeOptions: {
+		select: new TerraDrawSelectMode({
+			flags: {
+				// only update polygon settings for select mode.
+				// default settings will be used for other geometry types
+				polygon: {
+					feature: {
+						draggable: false, // users cannot drag to move polygon
+						rotateable: true,
+						scaleable: true,
+						coordinates: {
+							midpoints: false, // users cannot add a node on the middle of edge.
+							draggable: true,
+							deletable: false // users cannot delete a node.
+						}
+					}
+				}
+			}
+		})
+	}
 });
 map.addControl(drawControl, 'top-left');
 		`}

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -6,6 +6,7 @@
 	import '../../scss/maplibre-gl-terradraw.scss';
 	import type { PageData } from './$types.js';
 	import { CodeBlock } from '@skeletonlabs/skeleton';
+	import { TerraDrawSelectMode } from 'terra-draw';
 
 	export let data: PageData;
 	let mapContainer: HTMLDivElement;
@@ -45,7 +46,27 @@
 				'freehand',
 				'select'
 			],
-			open: true
+			open: true,
+			modeOptions: {
+				select: new TerraDrawSelectMode({
+					flags: {
+						// only update polygon settings for select mode.
+						// default settings will be used for other geometry types
+						polygon: {
+							feature: {
+								draggable: false,
+								rotateable: true,
+								scaleable: true,
+								coordinates: {
+									midpoints: false,
+									draggable: true,
+									deletable: false
+								}
+							}
+						}
+					}
+				})
+			}
 		});
 		map.addControl(drawControl, 'top-left');
 


### PR DESCRIPTION
In v0.1.0, it used the second argument of constructor to customise drawing options for each Terra Draw mode. The second argment was now merged into the first argument as shown in the below sample code.

```js
const drawControl = new MaplibreTerradrawControl({
	// only show polgyon, line and select mode.
	modes: ['polygon', 'linestring', 'select'],
	modeOptions: {
		select: new TerraDrawSelectMode({
			flags: {
				// only update polygon settings for select mode.
				// default settings will be used for other geometry types
				// in this case, line uses default options of the plugin.
				polygon: {
					feature: {
						draggable: false, // users cannot drag to move polygon
						rotateable: true,
						scaleable: true,
						coordinates: {
							midpoints: false, // users cannot add a node on the middle of edge.
							draggable: true,
							deletable: false // users cannot delete a node.
						}
					}
				}
			}
		})
	}
});
map.addControl(drawControl, 'top-left');
```