### PR TITLE
feat: add 'delete' mode to arrow users to show/hide delete button in prefered order.

### DIFF
--- a/.changeset/modern-buses-swim.md
+++ b/.changeset/modern-buses-swim.md
@@ -1,0 +1,18 @@
+---
+'@watergis/maplibre-gl-terradraw': minor
+---
+
+feat: add 'delete' mode to arrow users to show/hide delete button in prefered order.
+
+```ts
+const drawControl = new MaplibreTerradrawControl({
+	modes: [
+		'render',
+		'select',
+		'point',
+		'delete' // delete mode must be specified to show delete button in the tool
+	],
+	open: true
+});
+map.addControl(drawControl, 'top-left');
+```

--- a/src/lib/MaplibreTerradrawControl.ts
+++ b/src/lib/MaplibreTerradrawControl.ts
@@ -11,7 +11,6 @@ export class MaplibreTerradrawControl implements IControl {
 	private controlContainer?: HTMLElement;
 	private map?: Map;
 	private modeButtons: { [key: string]: HTMLButtonElement } = {};
-	private deleteButton?: HTMLButtonElement;
 	private isExpanded = false;
 
 	private terradraw?: TerraDraw;
@@ -87,25 +86,9 @@ export class MaplibreTerradrawControl implements IControl {
 			this.addTerradrawButton(m.mode as TerradrawMode);
 		});
 
-		this.deleteButton = document.createElement('button');
-		this.deleteButton.classList.add('maplibregl-terradraw-add-control');
-		this.deleteButton.classList.add(`maplibregl-terradraw-delete-button`);
-		if (!this.isExpanded) {
-			this.deleteButton.classList.add('hidden');
-		}
-		this.deleteButton.type = 'button';
-		this.deleteButton.title = this.capitalize('delete');
-		this.deleteButton.addEventListener('click', () => {
-			if (!this.terradraw) return;
-			if (!this.terradraw.enabled) return;
-			this.terradraw.clear();
-			this.deactivate();
-		});
-
 		Object.values(this.modeButtons).forEach((ele) => {
 			this.controlContainer?.appendChild(ele);
 		});
-		this.controlContainer.appendChild(this.deleteButton);
 
 		return this.controlContainer;
 	}
@@ -163,7 +146,7 @@ export class MaplibreTerradrawControl implements IControl {
 				item.classList.remove('hidden');
 			}
 		}
-		const addButton = document.getElementsByClassName('maplibregl-terradraw-add-render-button');
+		const addButton = document.getElementsByClassName('maplibregl-terradraw-render-button');
 		if (addButton && addButton.length > 0) {
 			if (this.isExpanded) {
 				addButton.item(0)?.classList.remove('enabled');
@@ -199,11 +182,12 @@ export class MaplibreTerradrawControl implements IControl {
 	 */
 	private addTerradrawButton(mode: TerradrawMode) {
 		const btn = document.createElement('button');
-		btn.classList.add(`maplibregl-terradraw-add-${mode}-button`);
 		btn.type = 'button';
 		this.modeButtons[mode] = btn;
 
 		if (mode === 'render') {
+			btn.classList.add(`maplibregl-terradraw-${mode}-button`);
+
 			if (this.isExpanded) {
 				btn.classList.add('enabled');
 			}
@@ -217,19 +201,33 @@ export class MaplibreTerradrawControl implements IControl {
 				btn.classList.add('hidden');
 			}
 			btn.title = this.capitalize(mode.replace(/-/g, ' '));
-			btn.addEventListener('click', () => {
-				if (!this.terradraw) return;
 
-				const isActive = btn.classList.contains('active');
+			if (mode === 'delete') {
+				btn.classList.add(`maplibregl-terradraw-${mode}-button`);
 
-				this.activate();
-				this.resetActiveMode();
+				btn.addEventListener('click', () => {
+					if (!this.terradraw) return;
+					if (!this.terradraw.enabled) return;
+					this.terradraw.clear();
+					this.deactivate();
+				});
+			} else {
+				btn.classList.add(`maplibregl-terradraw-add-${mode}-button`);
 
-				if (!isActive) {
-					this.terradraw.setMode(mode);
-					btn.classList.add('active');
-				}
-			});
+				btn.addEventListener('click', () => {
+					if (!this.terradraw) return;
+
+					const isActive = btn.classList.contains('active');
+
+					this.activate();
+					this.resetActiveMode();
+
+					if (!isActive) {
+						this.terradraw.setMode(mode);
+						btn.classList.add('active');
+					}
+				});
+			}
 		}
 	}
 

--- a/src/lib/constants/AvailableModes.ts
+++ b/src/lib/constants/AvailableModes.ts
@@ -10,5 +10,6 @@ export const AvailableModes = [
 	'freehand',
 	'angled-rectangle',
 	'select',
-	'render'
+	'render',
+	'delete'
 ] as const;

--- a/src/lib/constants/defaultControlOptions.ts
+++ b/src/lib/constants/defaultControlOptions.ts
@@ -13,7 +13,8 @@ export const defaultControlOptions: ControlOptions = {
 		'angled-rectangle',
 		'circle',
 		'freehand',
-		'select'
+		'select',
+		'delete'
 	],
 	open: false
 };

--- a/src/lib/constants/getDefaultModeOptions.ts
+++ b/src/lib/constants/getDefaultModeOptions.ts
@@ -117,6 +117,10 @@ export const getDefaultModeOptions = () => {
 					}
 				}
 			}
+		}),
+		delete: new TerraDrawRenderMode({
+			modeName: 'delete',
+			styles: {}
 		})
 	};
 	return modeOptions;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -105,7 +105,8 @@ const drawControl = new MaplibreTerradrawControl({
 	modes: [
 		'render', 
 		'select',
-		'point'
+		'point',
+		'delete'
 	]
 });
 map.addControl(drawControl, 'top-left');
@@ -129,7 +130,7 @@ map.addControl(drawControl, 'top-left');
 			code={`
 const drawControl = new MaplibreTerradrawControl({
 	// only show polgyon, line and select mode.
-	modes: ['render', 'polygon', 'linestring', 'select'],
+	modes: ['render', 'polygon', 'linestring', 'select', 'delete'],
 	modeOptions: {
 		select: new TerraDrawSelectMode({
 			flags: {
@@ -170,7 +171,8 @@ map.addControl(drawControl, 'top-left');
 const drawControl = new MaplibreTerradrawControl({
 	modes: [
 		'select',
-		'point'
+		'point',
+		'delete'
 	],
 	open: true,
 });

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -50,7 +50,8 @@
 				'angled-rectangle',
 				'circle',
 				'freehand',
-				'select'
+				'select',
+				'delete'
 			],
 			open: true,
 			modeOptions: {

--- a/src/scss/maplibre-gl-terradraw.scss
+++ b/src/scss/maplibre-gl-terradraw.scss
@@ -1,4 +1,4 @@
-.maplibregl-terradraw-add-render-button {
+.maplibregl-terradraw-render-button {
 	background: url('data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20height%3D%2224px%22%20viewBox%3D%220%20-960%20960%20960%22%20width%3D%2224px%22%20fill%3D%22%235f6368%22%3E%3Cpath%20d%3D%22M200-200h57l391-391-57-57-391%20391v57Zm-80%2080v-170l528-527q12-11%2026.5-17t30.5-6q16%200%2031%206t26%2018l55%2056q12%2011%2017.5%2026t5.5%2030q0%2016-5.5%2030.5T817-647L290-120H120Zm640-584-56-56%2056%2056Zm-141%2085-28-29%2057%2057-29-28Z%22%2F%3E%3C%2Fsvg%3E');
 	background-position: center;
 	background-repeat: no-repeat;

--- a/static/assets/maplibre-npm-example.txt
+++ b/static/assets/maplibre-npm-example.txt
@@ -12,7 +12,7 @@ const map = new Map({
 // As default, all Terra Draw modes are enabled, 
 // you can disable options if you don't want to use them.
 const draw = new MaplibreTerradrawControl({
-    modes: ['render', 'point', 'linestring', 'polygon', 'rectangle', 'angled-rectangle', 'circle', 'freehand', 'select'],
+    modes: ['render', 'point', 'linestring', 'polygon', 'rectangle', 'angled-rectangle', 'circle', 'freehand', 'select', 'delete'],
     open: false,
 });
 map.addControl(drawControl, 'top-left');

--- a/static/index_cdn.html
+++ b/static/index_cdn.html
@@ -41,7 +41,8 @@
 					'angled-rectangle',
 					'circle',
 					'freehand',
-					'select'
+					'select',
+					'delete'
 				],
 				open: false
 			});


### PR DESCRIPTION
now 'delete' mode is needed in constructor option.

```ts
const drawControl = new MaplibreTerradrawControl({
	modes: [
		'render',
		'select',
		'point',
		'delete' // delete mode must be specified to show delete button in the tool
	],
	open: true
});
map.addControl(drawControl, 'top-left');
```