### PR TITLE
call this.deactivate() when calling map.removeControl(drawControl)

### DIFF
--- a/.changeset/cyan-jars-think.md
+++ b/.changeset/cyan-jars-think.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+call this.deactivate() when calling map.removeControl(drawControl)

--- a/src/lib/MaplibreTerradrawControl.ts
+++ b/src/lib/MaplibreTerradrawControl.ts
@@ -97,7 +97,7 @@ export class MaplibreTerradrawControl implements IControl {
 		if (!this.controlContainer || !this.controlContainer.parentNode || !this.map) {
 			return;
 		}
-		this.terradraw?.stop();
+		this.deactivate();
 		this.modeButtons = {};
 		this.terradraw = undefined;
 		this.map = undefined;


### PR DESCRIPTION
addressing #67 
as `this.deactivate()` calls `this.terradraw.stop();` we can replace the previous line.