### PR TITLE
Fix/reset state

### DIFF
--- a/.changeset/large-emus-raise.md
+++ b/.changeset/large-emus-raise.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: in some timing, TerraDraw throw error of 'Can not register unless mode is unregistered'. Hence, it resets \_state in modes as unregistered before adding.

--- a/src/lib/MaplibreTerradrawControl.ts
+++ b/src/lib/MaplibreTerradrawControl.ts
@@ -74,7 +74,11 @@ export class MaplibreTerradrawControl implements IControl {
 		// sometimes, an error of 'Can not register unless mode is unregistered' is thrown by terradraw,
 		// thus, force reset mode state as unregistered
 		modes.forEach((m) => {
-			m._state = 'unregistered';
+			if (m.state !== 'unregistered') {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore
+				m._state = 'unregistered';
+			}
 		});
 
 		// if no render button is specified, it add hidden render mode

--- a/src/lib/MaplibreTerradrawControl.ts
+++ b/src/lib/MaplibreTerradrawControl.ts
@@ -71,6 +71,12 @@ export class MaplibreTerradrawControl implements IControl {
 			}
 		});
 
+		// sometimes, an error of 'Can not register unless mode is unregistered' is thrown by terradraw,
+		// thus, force reset mode state as unregistered
+		modes.forEach((m) => {
+			m._state = 'unregistered';
+		});
+
 		// if no render button is specified, it add hidden render mode
 		if (!this.options?.modes?.includes('render')) {
 			modes.push(


### PR DESCRIPTION
In TerraDraw's each mode, it returns the error of 'Can not register unless mode is unregistered' in register funciton.

https://github.com/JamesLMilner/terra-draw/blob/544eb66ab6e0914b8c1c222fff1260937f01f135/src/modes/base.mode.ts#L126-L153

In some timing, this error is thrown by terradraw, I am not sure why it is happened. thus, force reset mode state as unregistered. It works fine in my local. hope it can solve it.

