### PR TITLE
fix: add select and delete-selection for default mode of MeasureControl

### DIFF
--- a/.changeset/wise-tomatoes-roll.md
+++ b/.changeset/wise-tomatoes-roll.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: add select and delete-selection for default mode of MeasureControl

--- a/src/lib/constants/defaultMeasureControlOptions.ts
+++ b/src/lib/constants/defaultMeasureControlOptions.ts
@@ -24,6 +24,8 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 		'sector',
 		'circle',
 		'freehand',
+		'select',
+		'delete-selection',
 		'delete'
 	],
 	open: false,


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
