### PR TITLE
fix: use TerraDrawExtend.BaseAdapterConfig type for adapterOptions.

### DIFF
--- a/.changeset/orange-kings-melt.md
+++ b/.changeset/orange-kings-melt.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: use TerraDrawExtend.BaseAdapterConfig type for adapterOptions.

--- a/src/lib/interfaces/MeasureControlOptions.ts
+++ b/src/lib/interfaces/MeasureControlOptions.ts
@@ -1,6 +1,7 @@
 import type { CircleLayerSpecification, SymbolLayerSpecification } from 'maplibre-gl';
 import type { ModeOptions } from './ModeOptions.js';
 import type { MeasureControlMode } from './MeasureControlMode.js';
+import type { TerraDrawExtend } from 'terra-draw';
 
 /**
  * MeasureControl Plugin control constructor options
@@ -26,15 +27,10 @@ export interface MeasureControlOptions {
 	modeOptions?: ModeOptions;
 
 	/**
-	 * TerraDrawMaplibreGLAdapter options. Please refer the default adapter settings at the below TerraDraw code.
+	 * TerraDrawMaplibreGLAdapter options. Please refer the default adapter settings (BaseAdapterConfig) at the below TerraDraw code.
 	 * https://github.com/JamesLMilner/terra-draw/blob/806e319d5680a3f69edeff7dd629da3f1b4ff9bf/src/adapters/common/base.adapter.ts#L28-L48
 	 */
-	adapterOptions?: {
-		coordinatePrecision?: number;
-		minPixelDragDistanceDrawing?: number;
-		minPixelDragDistance?: number;
-		minPixelDragDistanceSelecting?: number;
-	};
+	adapterOptions?: TerraDrawExtend.BaseAdapterConfig;
 
 	/**
 	 * Maplibre symbol layer specification (on line nodes) for line distance layer

--- a/src/lib/interfaces/TerradrawControlOptions.ts
+++ b/src/lib/interfaces/TerradrawControlOptions.ts
@@ -1,5 +1,6 @@
 import type { ModeOptions } from './ModeOptions.js';
 import type { TerradrawMode } from './TerradrawMode.js';
+import type { TerraDrawExtend } from 'terra-draw';
 
 /**
  * Terradraw Control Plugin control constructor options
@@ -25,13 +26,8 @@ export interface TerradrawControlOptions {
 	modeOptions?: ModeOptions;
 
 	/**
-	 * TerraDrawMaplibreGLAdapter options. Please refer the default adapter settings at the below TerraDraw code.
+	 * TerraDrawMaplibreGLAdapter options. Please refer the default adapter settings (BaseAdapterConfig) at the below TerraDraw code.
 	 * https://github.com/JamesLMilner/terra-draw/blob/806e319d5680a3f69edeff7dd629da3f1b4ff9bf/src/adapters/common/base.adapter.ts#L28-L48
 	 */
-	adapterOptions?: {
-		coordinatePrecision?: number;
-		minPixelDragDistanceDrawing?: number;
-		minPixelDragDistance?: number;
-		minPixelDragDistanceSelecting?: number;
-	};
+	adapterOptions?: TerraDrawExtend.BaseAdapterConfig;
 }


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Use `TerraDrawExtend.BaseAdapterConfig` type for `adapterOptions`. But typescript does not work, and it shows `/*unresolved*/ any`.

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documentation
- [x] Others (refactoring)
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
