### PR TITLE
fix: fixed a bug of layer ordering of MeasureControl when addFeatures is used to restore data.

### DIFF
--- a/.changeset/small-mirrors-marry.md
+++ b/.changeset/small-mirrors-marry.md
@@ -1,0 +1,10 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+- fix: fixed a bug of layer ordering of MeasureControl when addFeatures is used to restore data.
+- fix: added recalc public method to re-measure area/distance of features.
+- fix: delete text-font from default measure label style
+- fix: adjusted text-size and text-letter-spacing to look better
+- fix: adjusted measure label and layer style to avoid using true black and white.
+- fix: use `$type` to filter feature for measuring label layers.

--- a/src/lib/constants/defaultMeasureControlOptions.ts
+++ b/src/lib/constants/defaultMeasureControlOptions.ts
@@ -34,75 +34,79 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 	modeOptions: {
 		linestring: new TerraDrawLineStringMode({
 			styles: {
-				lineStringColor: '#000000',
+				lineStringColor: '#232E3D',
 				lineStringWidth: 2,
 				closingPointColor: '#FFFFFF',
-				closingPointWidth: 5,
-				closingPointOutlineColor: '#000000',
+				closingPointWidth: 3,
+				closingPointOutlineColor: '#232E3D',
 				closingPointOutlineWidth: 1
 			}
 		}),
 		polygon: new TerraDrawPolygonMode({
 			styles: {
-				fillColor: '#FFFFFF',
+				fillColor: '#EDEFF0',
 				fillOpacity: 0.7,
-				outlineColor: '#000000',
+				outlineColor: '#232E3D',
 				outlineWidth: 2,
-				closingPointColor: '#FFFFFF',
-				closingPointWidth: 5,
-				closingPointOutlineColor: '#000000',
+				closingPointColor: '#FAFAFA',
+				closingPointWidth: 3,
+				closingPointOutlineColor: '#232E3D',
 				closingPointOutlineWidth: 1
 			}
 		}),
 		rectangle: new TerraDrawRectangleMode({
 			styles: {
-				fillColor: '#FFFFFF',
+				fillColor: '#EDEFF0',
 				fillOpacity: 0.7,
-				outlineColor: '#000000',
+				outlineColor: '#232E3D',
 				outlineWidth: 2
 			}
 		}),
 		'angled-rectangle': new TerraDrawAngledRectangleMode({
 			styles: {
-				fillColor: '#FFFFFF',
+				fillColor: '#EDEFF0',
 				fillOpacity: 0.7,
-				outlineColor: '#000000',
+				outlineColor: '#232E3D',
 				outlineWidth: 2
 			}
 		}),
 		circle: new TerraDrawCircleMode({
 			styles: {
-				fillColor: '#FFFFFF',
+				fillColor: '#EDEFF0',
 				fillOpacity: 0.7,
-				outlineColor: '#000000',
+				outlineColor: '#232E3D',
 				outlineWidth: 2
 			}
 		}),
 		freehand: new TerraDrawFreehandMode({
 			styles: {
-				fillColor: '#FFFFFF',
+				fillColor: '#EDEFF0',
 				fillOpacity: 0.7,
-				outlineColor: '#000000',
-				outlineWidth: 2
+				outlineColor: '#232E3D',
+				outlineWidth: 2,
+				closingPointColor: '#FAFAFA',
+				closingPointWidth: 3,
+				closingPointOutlineColor: '#232E3D',
+				closingPointOutlineWidth: 1
 			}
 		}),
 		sensor: new TerraDrawSensorMode({
 			styles: {
-				fillColor: '#FFFFFF',
+				fillColor: '#EDEFF0',
 				fillOpacity: 0.7,
-				outlineColor: '#000000',
+				outlineColor: '#232E3D',
 				outlineWidth: 2,
-				centerPointColor: '#FFFFFF',
-				centerPointWidth: 5,
-				centerPointOutlineColor: '#000000',
+				centerPointColor: '#FAFAFA',
+				centerPointWidth: 3,
+				centerPointOutlineColor: '#232E3D',
 				centerPointOutlineWidth: 1
 			}
 		}),
 		sector: new TerraDrawSectorMode({
 			styles: {
-				fillColor: '#FFFFFF',
+				fillColor: '#EDEFF0',
 				fillOpacity: 0.7,
-				outlineColor: '#000000',
+				outlineColor: '#232E3D',
 				outlineWidth: 2
 			}
 		})
@@ -140,9 +144,9 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 			'text-justify': 'center'
 		},
 		paint: {
-			'text-halo-color': '#ffffff',
-			'text-halo-width': 10,
-			'text-color': '#000000'
+			'text-halo-color': '#F7F7F7',
+			'text-halo-width': 2,
+			'text-color': '#232E3D'
 		}
 	},
 	lineLayerNodeSpec: {
@@ -152,7 +156,7 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 		filter: ['==', '$type', 'Point'],
 		layout: {},
 		paint: {
-			'circle-radius': 5,
+			'circle-radius': 3,
 			'circle-color': '#FFFFFF',
 			'circle-stroke-color': '#000000',
 			'circle-stroke-width': 1
@@ -171,9 +175,9 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 			'text-overlap': 'always'
 		},
 		paint: {
-			'text-halo-color': '#ffffff',
-			'text-halo-width': 4,
-			'text-color': '#000000'
+			'text-halo-color': '#F7F7F7',
+			'text-halo-width': 2,
+			'text-color': '#232E3D'
 		}
 	}
 };

--- a/src/lib/constants/defaultMeasureControlOptions.ts
+++ b/src/lib/constants/defaultMeasureControlOptions.ts
@@ -111,7 +111,7 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 		id: 'terradraw-measure-line-label',
 		type: 'symbol',
 		source: 'terradraw-measure-line-source',
-		filter: ['match', ['geometry-type'], ['Point'], true, false],
+		filter: ['==', '$type', 'Point'],
 		layout: {
 			'text-field': [
 				'concat',
@@ -149,7 +149,7 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 		id: 'terradraw-measure-line-node',
 		type: 'circle',
 		source: 'terradraw-measure-line-source',
-		filter: ['match', ['geometry-type'], ['Point'], true, false],
+		filter: ['==', '$type', 'Point'],
 		layout: {},
 		paint: {
 			'circle-radius': 5,
@@ -162,7 +162,7 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 		id: 'terradraw-measure-polygon-label',
 		type: 'symbol',
 		source: 'terradraw-measure-polygon-source',
-		filter: ['match', ['geometry-type'], ['Point'], true, false],
+		filter: ['==', '$type', 'Point'],
 		layout: {
 			'text-field': ['concat', ['to-string', ['get', 'area']], ' ', ['get', 'unit']],
 			'symbol-placement': 'point',

--- a/src/lib/constants/defaultMeasureControlOptions.ts
+++ b/src/lib/constants/defaultMeasureControlOptions.ts
@@ -136,7 +136,6 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 				]
 			],
 			'symbol-placement': 'point',
-			'text-font': ['Open Sans Semibold'],
 			'text-size': [
 				'interpolate',
 				['linear'],
@@ -185,7 +184,6 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 		layout: {
 			'text-field': ['concat', ['to-string', ['get', 'area']], ' ', ['get', 'unit']],
 			'symbol-placement': 'point',
-			'text-font': ['Open Sans Semibold'],
 			'text-size': [
 				'interpolate',
 				['linear'],

--- a/src/lib/constants/defaultMeasureControlOptions.ts
+++ b/src/lib/constants/defaultMeasureControlOptions.ts
@@ -137,11 +137,26 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 			],
 			'symbol-placement': 'point',
 			'text-font': ['Open Sans Semibold'],
-			'text-size': 12,
+			'text-size': [
+				'interpolate',
+				['linear'],
+				['zoom'],
+				5,
+				10,
+				10,
+				12.0,
+				13,
+				14.0,
+				14,
+				16.0,
+				18,
+				18.0
+			],
 			'text-overlap': 'always',
 			'text-variable-anchor': ['left', 'right', 'top', 'bottom'],
-			'text-radial-offset': 1,
-			'text-justify': 'center'
+			'text-radial-offset': 0.5,
+			'text-justify': 'center',
+			'text-letter-spacing': 0.05
 		},
 		paint: {
 			'text-halo-color': '#F7F7F7',
@@ -171,8 +186,23 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 			'text-field': ['concat', ['to-string', ['get', 'area']], ' ', ['get', 'unit']],
 			'symbol-placement': 'point',
 			'text-font': ['Open Sans Semibold'],
-			'text-size': 12,
-			'text-overlap': 'always'
+			'text-size': [
+				'interpolate',
+				['linear'],
+				['zoom'],
+				5,
+				10,
+				10,
+				12.0,
+				13,
+				14.0,
+				14,
+				16.0,
+				18,
+				18.0
+			],
+			'text-overlap': 'always',
+			'text-letter-spacing': 0.05
 		},
 		paint: {
 			'text-halo-color': '#F7F7F7',

--- a/src/routes/demo/+page.svelte
+++ b/src/routes/demo/+page.svelte
@@ -104,6 +104,12 @@
 				);
 				if (initData.length > 0) {
 					drawInstance?.addFeatures(initData);
+
+					if (isMeasure) {
+						map?.once('idle', () => {
+							(drawControl as MaplibreMeasureControl).recalc();
+						});
+					}
 				}
 			});
 		})

--- a/tests/routes/examples/index.spec.ts
+++ b/tests/routes/examples/index.spec.ts
@@ -14,7 +14,8 @@ test.describe('each examples page test', () => {
 		'measure-control',
 		'select-event',
 		'coordinate-precision',
-		'custom-icon'
+		'custom-icon',
+		'query-elevation'
 	]) {
 		test(`${option} example page has expected to have title`, async ({ page }) => {
 			await page.goto(`/examples/${option}`);


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

- fix: fixed a bug of layer ordering of MeasureControl when addFeatures is used to restore data.
- fix: added recalc public method to re-measure area/distance of features.
- fix: delete text-font from default measure label style
- fix: adjusted text-size and text-letter-spacing to look better
- fix: adjusted measure label and layer style to avoid using true black and white.
- fix: use `$type` to filter feature for measuring label layers.

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
