### PR TITLE
feat: upgrade TerraDraw tp v1.0.0 from beta

### DIFF
--- a/.changeset/little-mugs-join.md
+++ b/.changeset/little-mugs-join.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': major
+---
+
+feat: upgrade TerraDraw tp v1.0.0 from beta. Drop support of maplibre v2 and v3 since it is no longer supported by TerraDraw.

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"globals": "^15.14.0",
 		"highlight.js": "^11.11.1",
 		"lefthook": "^1.10.3",
-		"maplibre-gl": "^5.0.0",
+		"maplibre-gl": "^5.0.1",
 		"postcss": "^8.4.49",
 		"postcss-cli": "^11.0.0",
 		"prettier": "^3.4.2",
@@ -78,15 +78,17 @@
 		"svelte": "^5.17.3",
 		"svelte-check": "^4.1.3",
 		"tailwindcss": "^3.4.17",
-		"terra-draw": "1.0.0-beta.11",
+		"terra-draw": "^1.0.0",
+		"terra-draw-maplibre-gl-adapter": "^1.0.0",
 		"typedoc": "^0.27.6",
 		"typescript": "^5.7.3",
 		"typescript-eslint": "^8.19.1",
 		"vite": "^6.0.7"
 	},
 	"peerDependencies": {
-		"maplibre-gl": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
-		"terra-draw": "^1.0.0-beta.11"
+		"maplibre-gl": "^4.0.0 || ^5.0.0",
+		"terra-draw": "^1.0.0",
+		"terra-draw-maplibre-gl-adapter": "^1.0.0"
 	},
 	"peerDependenciesMeta": {
 		"terradraw": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,7 +81,7 @@ importers:
         specifier: ^1.10.3
         version: 1.10.3
       maplibre-gl:
-        specifier: ^5.0.0
+        specifier: ^5.0.1
         version: 5.0.1
       postcss:
         specifier: ^8.4.49
@@ -114,8 +114,11 @@ importers:
         specifier: ^3.4.17
         version: 3.4.17
       terra-draw:
-        specifier: 1.0.0-beta.11
-        version: 1.0.0-beta.11
+        specifier: ^1.0.0
+        version: 1.0.0
+      terra-draw-maplibre-gl-adapter:
+        specifier: ^1.0.0
+        version: 1.0.0(maplibre-gl@5.0.1)(terra-draw@1.0.0)
       typedoc:
         specifier: ^0.27.6
         version: 0.27.6(typescript@5.7.3)
@@ -2353,8 +2356,14 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
 
-  terra-draw@1.0.0-beta.11:
-    resolution: {integrity: sha512-Xo8OA997ng7w7HmWd7lt7yi/MeXEd/bKilUPSLZo1XTB8vuhCwJovJc0//LQzrOdeJKKgzR0dF3YZL9TDVDpDA==}
+  terra-draw-maplibre-gl-adapter@1.0.0:
+    resolution: {integrity: sha512-SB95kcxzMNPPljTb2sdd3fqPTzsE2WG0hRpkrWN3kf+ZiXRHFsfBgW2RUbmHp9BnXSy9hB8XwiqSKnOVhNLV3w==}
+    peerDependencies:
+      maplibre-gl: '>=4'
+      terra-draw: ^1.0.0
+
+  terra-draw@1.0.0:
+    resolution: {integrity: sha512-LMD5wLHHSfkXOX0eGjhUV/Pnxedn5MvsKBvGOP6txCY1D1LAIVnIx1g+trTXfBHUjogDJj/vmswsGMD/5LtNKQ==}
 
   thenby@1.3.4:
     resolution: {integrity: sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ==}
@@ -4774,7 +4783,12 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terra-draw@1.0.0-beta.11: {}
+  terra-draw-maplibre-gl-adapter@1.0.0(maplibre-gl@5.0.1)(terra-draw@1.0.0):
+    dependencies:
+      maplibre-gl: 5.0.1
+      terra-draw: 1.0.0
+
+  terra-draw@1.0.0: {}
 
   thenby@1.3.4: {}
 

--- a/src/lib/controls/MaplibreTerradrawControl.ts
+++ b/src/lib/controls/MaplibreTerradrawControl.ts
@@ -1,10 +1,6 @@
 import type { ControlPosition, IControl, Map } from 'maplibre-gl';
-import {
-	type GeoJSONStoreFeatures,
-	TerraDraw,
-	TerraDrawMapLibreGLAdapter,
-	TerraDrawRenderMode
-} from 'terra-draw';
+import { type GeoJSONStoreFeatures, TerraDraw, TerraDrawRenderMode } from 'terra-draw';
+import { TerraDrawMapLibreGLAdapter } from 'terra-draw-maplibre-gl-adapter';
 import type {
 	TerradrawControlOptions,
 	EventType,


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I think it is a good timing to upgrade the plugin version to v1 together with the v1 release of TerraDraw itself.

- Upgrade TerraDraw tp v1.0.0
  - Use `TerraDrawMapLibreGLAdapter` from `terra-draw-maplibre-gl-adapter` package now.
- Dropped support for maplibre v2 and v3

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
