### PR TITLE
chore: upgrade pnpm to v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
+        with:
+          version: 10
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -65,6 +67,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
+        with:
+          version: 10
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -90,6 +94,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
+        with:
+          version: 10
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 env:
   CI: true
   PNPM_CACHE_FOLDER: .pnpm-store
+  PNPM_VERSION: 10
 
 jobs:
   lint:
@@ -25,6 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
+        with:
+          version: ${{env.PNPM_VERSION}}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -47,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
         with:
-          version: 10
+          version: ${{env.PNPM_VERSION}}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -68,7 +71,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
         with:
-          version: 10
+          version: ${{env.PNPM_VERSION}}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -95,7 +98,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
         with:
-          version: 10
+          version: ${{env.PNPM_VERSION}}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
   CI: true
   PNPM_CACHE_FOLDER: .pnpm-store
   NODE_VERSION: 22
+  PNPM_VERSION: 10
 
 jobs:
   release:
@@ -29,7 +30,7 @@ jobs:
           fetch-depth: 0
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
         with:
-          version: 10
+          version: ${{env.PNPM_VERSION}}
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
@@ -61,7 +62,7 @@ jobs:
 
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
         with:
-          version: 10
+          version: ${{env.PNPM_VERSION}}
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
+        with:
+          version: 10
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:
@@ -58,6 +60,8 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 #v4
+        with:
+          version: 10
       - name: Setup Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@v4
         with:

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.27.12",
+		"@eslint/js": "^9.20.0",
 		"@playwright/test": "^1.50.1",
 		"@skeletonlabs/skeleton": "^2.11.0",
 		"@skeletonlabs/tw-plugin": "^0.4.1",
@@ -119,8 +120,14 @@
 		"url": "https://github.com/watergis/maplibre-gl-terradraw/issues"
 	},
 	"homepage": "https://github.com/watergis/maplibre-gl-terradraw#readme",
-	"packageManager": "pnpm@9.15.4",
 	"engines": {
-		"pnpm": "^9.0.0"
+		"pnpm": "^10.0.0"
+	},
+	"pnpm": {
+		"onlyBuiltDependencies": [
+			"@parcel/watcher",
+			"esbuild",
+			"lefthook"
+		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -119,15 +119,5 @@
 	"bugs": {
 		"url": "https://github.com/watergis/maplibre-gl-terradraw/issues"
 	},
-	"homepage": "https://github.com/watergis/maplibre-gl-terradraw#readme",
-	"engines": {
-		"pnpm": "^10.0.0"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"@parcel/watcher",
-			"esbuild",
-			"lefthook"
-		]
-	}
+	"homepage": "https://github.com/watergis/maplibre-gl-terradraw#readme"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.12
         version: 2.27.12
+      '@eslint/js':
+        specifier: ^9.20.0
+        version: 9.20.0
       '@playwright/test':
         specifier: ^1.50.1
         version: 1.50.1


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

deleted `packageManager` from package.json since cloudflare fails with pnpm v10. Instead, add pnpm version in CI to use v10

## What this PR is going to change for

Select items related to this PR.

- [ ] maplibre-gl-terradraw
- [ ] documentation
- [x] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documentation
- [x] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [ ] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
