### PR TITLE
fix: remove elevation label for point if computeElevation property is disabled.

### DIFF
--- a/.changeset/spicy-spoons-develop.md
+++ b/.changeset/spicy-spoons-develop.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: remove elevation label for point if computeElevation property is disabled.

--- a/src/lib/controls/MaplibreMeasureControl.ts
+++ b/src/lib/controls/MaplibreMeasureControl.ts
@@ -997,18 +997,19 @@ export class MaplibreMeasureControl extends MaplibreTerradrawControl {
 					typeof geojsonSource.data !== 'string' &&
 					geojsonSource.data.type === 'FeatureCollection'
 				) {
-					geojsonSource.data.features = geojsonSource.data.features.filter(
-						(f) => f.properties?.originalId !== id
-					);
+					geojsonSource.data.features = geojsonSource.data.features.filter((f) => f.id !== id);
 				}
 
 				feature = this.queryElevationByPoint(feature);
 
-				if (
-					typeof geojsonSource.data !== 'string' &&
-					geojsonSource.data.type === 'FeatureCollection'
-				) {
-					geojsonSource.data.features.push(feature);
+				// add elevation label feature if computeElevation is only enabled.
+				if (this.computeElevation === true) {
+					if (
+						typeof geojsonSource.data !== 'string' &&
+						geojsonSource.data.type === 'FeatureCollection'
+					) {
+						geojsonSource.data.features.push(feature);
+					}
 				}
 
 				// update GeoJSON source with new data


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #225

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
