### PR TITLE
docs: added LightSwitch control in header to switch between light and dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -5,6 +5,7 @@
 @import '@skeletonlabs/skeleton/themes/wintry';
 
 @source '../node_modules/@skeletonlabs/skeleton-svelte/dist';
+@custom-variant dark (&:where([data-mode="dark"], [data-mode="dark"] *));
 
 html,
 body {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import IconGithub from '@lucide/svelte/icons/github';
 	import IconTwitter from '@lucide/svelte/icons/twitter';
+	import LightSwitch from './LightSwitch.svelte';
 
 	import '../app.css';
 
@@ -37,13 +38,16 @@
 	<header class="sticky top-0 z-10 bg-gray-200">
 		<AppBar>
 			{#snippet lead()}
-				<a href="/"><strong class="text-xl text-nowrap uppercase">{data.metadata.title}</strong></a>
+				<a href="/" class="font-bold text-base md:text-xl text-nowrap uppercase">
+					{data.metadata.title}
+				</a>
 			{/snippet}
 			{#snippet trail()}
 				<nav class="flex justify-end gap-1">
+					<LightSwitch />
 					{#each data.nav as link (link.href)}
 						<a
-							class="btn hover:preset-tonal px-1"
+							class="btn hover:preset-tonal px-1 md:px-2"
 							href={link.href}
 							target="_blank"
 							title={link.icon}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -249,7 +249,8 @@
 		<p class="py-4">
 			See <a
 				href="https://watergis.github.io/maplibre-gl-terradraw"
-				class="text-blue-800 visited:text-purple-800">Plugin API documentation</a
+				class="text-blue-800 dark:text-surface-50 visited:text-purple-800 dark:visited:text-error-400"
+				>Plugin API documentation</a
 			>
 		</p>
 	</section>
@@ -288,9 +289,13 @@
 		</div>
 	</section>
 
-	<footer class="bg-gray-100 p-4">
+	<footer class="bg-surface-50 dark:bg-surface-900 p-4">
 		<p class="text-center w-full">
-			<a class="text-blue-800 visited:text-purple-800" href={data.metadata.contact} target="_blank">
+			<a
+				class="text-blue-800 dark:text-surface-50 visited:text-purple-800 dark:visited:text-error-400"
+				href={data.metadata.contact}
+				target="_blank"
+			>
 				©{year}
 				{data.metadata.author}
 			</a>

--- a/src/routes/LightSwitch.svelte
+++ b/src/routes/LightSwitch.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import IconMoon from '@lucide/svelte/icons/moon';
+	import IconSun from '@lucide/svelte/icons/sun';
+
+	let checked = $state(false);
+
+	const localStorageKey = 'light-dark-mode';
+
+	$effect(() => {
+		const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+		checked = prefersDark === true;
+	});
+
+	const onCheckedChange = (event: { checked: boolean }) => {
+		const mode = event.checked ? 'dark' : 'light';
+		document.documentElement.setAttribute('data-mode', mode);
+		localStorage.setItem(localStorageKey, mode);
+		checked = event.checked;
+	};
+</script>
+
+<svelte:head>
+	<script>
+		const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+		const mode = prefersDark ? 'dark' : 'light';
+		document.documentElement.setAttribute('data-mode', mode);
+	</script>
+</svelte:head>
+
+<button
+	type="button"
+	class="btn hover:preset-tonal px-1 md:px-2"
+	onclick={() => {
+		checked = !checked;
+		onCheckedChange({ checked });
+	}}
+>
+	<span>
+		{#if checked}
+			<IconMoon />
+		{:else}
+			<IconSun />
+		{/if}
+	</span>
+</button>


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I borrowed code from Skeleton website [here](https://www.skeleton.dev/docs/guides/cookbook/light-switch).

Get system setting as default to set either light or dark mode. Toggle light switch button to change mode. Original source code store state in local storage, but I removed it.

I adapted some colors of footer for dark mode

## What this PR is going to change for

Select items related to this PR.

- [ ] maplibre-gl-terradraw
- [x] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [x] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [ ] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
