### PR TITLE
fix: fixed MeasureControl constructor to copy modeOptions correctly

### DIFF
--- a/.changeset/pretty-llamas-invent.md
+++ b/.changeset/pretty-llamas-invent.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: fixed MeasureControl constructor to copy modeOptions correctly (sstructuredClone seems destroying terradraw's mode instances)

--- a/src/lib/controls/MaplibreMeasureControl.ts
+++ b/src/lib/controls/MaplibreMeasureControl.ts
@@ -150,6 +150,7 @@ export class MaplibreMeasureControl extends MaplibreTerradrawControl {
 	 */
 	constructor(options?: MeasureControlOptions) {
 		let measureOptions: MeasureControlOptions = structuredClone(defaultMeasureControlOptions);
+		measureOptions.modeOptions = defaultMeasureControlOptions.modeOptions;
 		if (options) {
 			measureOptions = Object.assign(measureOptions, options);
 		}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
