### PR TITLE
fix: clean td-point-lower and td-polygon-outline in cleanStyle function

### DIFF
--- a/.changeset/social-cougars-retire.md
+++ b/.changeset/social-cougars-retire.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: clean td-point-lower and td-polygon-outline in cleanStyle function

--- a/src/lib/helpers/cleanMaplibreStyle.ts
+++ b/src/lib/helpers/cleanMaplibreStyle.ts
@@ -1,7 +1,13 @@
 import { defaultMeasureControlOptions } from '../constants';
 import type { StyleSpecification } from 'maplibre-gl';
 
-export const TERRADRAW_SOURCE_IDS = ['td-point', 'td-linestring', 'td-polygon'];
+export const TERRADRAW_SOURCE_IDS = [
+	'td-point',
+	'td-point-lower',
+	'td-linestring',
+	'td-polygon',
+	'td-polygon-outline'
+];
 export const TERRADRAW_MEASURE_SOURCE_IDS = [
 	...TERRADRAW_SOURCE_IDS,
 	defaultMeasureControlOptions.polygonLayerSpec?.source as string,


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I realized layer name of terradraw was changed

https://github.com/JamesLMilner/terra-draw/blob/a712f0e655fa90dbe726f5721475b37aeec39312/packages/terra-draw-maplibre-gl-adapter/src/terra-draw-maplibre-gl-adapter.ts#L50-L80

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
