### PR TITLE
fix: fixed bug of using structuredClone in MeasureControl constructor.

### DIFF
--- a/.changeset/loose-phones-sell.md
+++ b/.changeset/loose-phones-sell.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: fixed bug of using structuredClone in MeasureControl constructor.

--- a/src/lib/controls/MaplibreMeasureControl.ts
+++ b/src/lib/controls/MaplibreMeasureControl.ts
@@ -149,8 +149,11 @@ export class MaplibreMeasureControl extends MaplibreTerradrawControl {
 	 * @param options Plugin control options
 	 */
 	constructor(options?: MeasureControlOptions) {
-		let measureOptions: MeasureControlOptions = structuredClone(defaultMeasureControlOptions);
-		measureOptions.modeOptions = defaultMeasureControlOptions.modeOptions;
+		let measureOptions: MeasureControlOptions = {
+			...JSON.parse(JSON.stringify(defaultMeasureControlOptions)),
+			modeOptions: { ...defaultMeasureControlOptions.modeOptions }
+		};
+
 		if (options) {
 			measureOptions = Object.assign(measureOptions, options);
 		}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

there is a problem of using structuredClone like below error

```
Uncaught DataCloneError: Failed to execute 'structuredClone' on 'Window': (L,K)=>{if(!this._enabled)return;this._eventListeners.change.forEach(H=>{H(L,K)});const{changed:V,unchanged:D}=...<omitted>...)} could not be cloned.
```

I changed to use JSON.parse(JSON.stringify()), then manually copy modeOptions (they are instances of class, so it cannot be copied by using JSON.parse(JSON.stringify(()) or structuredClone.

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
