### PR TITLE
fix: keep background layer after calling cleanStyle with excludeTerraDrawLayers option. Previously background layer is deleted mistakenly

### DIFF
--- a/.changeset/polite-states-know.md
+++ b/.changeset/polite-states-know.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: keep background layer after calling cleanStyle with excludeTerraDrawLayers option. Previously background layer is deleted mistakenly

--- a/src/lib/helpers/cleanMaplibreStryle.test.ts
+++ b/src/lib/helpers/cleanMaplibreStryle.test.ts
@@ -197,6 +197,12 @@ describe('cleanMaplibreStyle - default control', () => {
 		expect(result).toEqual(maplibreStyle);
 	});
 
+	it('should include background layer when excludeTerraDrawLayers is true', () => {
+		const result = cleanMaplibreStyle(maplibreStyle, { excludeTerraDrawLayers: true });
+		const backgroundLayer = result.layers.filter((layer) => layer.id === 'background');
+		expect(backgroundLayer.length).toBe(1);
+	});
+
 	it('should exclude TerraDraw layers when excludeTerraDrawLayers is true', () => {
 		const result = cleanMaplibreStyle(maplibreStyle, { excludeTerraDrawLayers: true });
 		expect(
@@ -226,6 +232,12 @@ describe('cleanMaplibreStyle - measure control', () => {
 	it('should return the original style when no options are set', () => {
 		const result = cleanMaplibreStyle(maplibreStyle);
 		expect(result).toEqual(maplibreStyle);
+	});
+
+	it('should include background layer when excludeTerraDrawLayers is true', () => {
+		const result = cleanMaplibreStyle(maplibreStyle, { excludeTerraDrawLayers: true });
+		const backgroundLayer = result.layers.filter((layer) => layer.id === 'background');
+		expect(backgroundLayer.length).toBe(1);
 	});
 
 	it('should exclude TerraDraw layers when excludeTerraDrawLayers is true', () => {

--- a/src/lib/helpers/cleanMaplibreStyle.ts
+++ b/src/lib/helpers/cleanMaplibreStyle.ts
@@ -49,7 +49,7 @@ export const cleanMaplibreStyle = (
 			});
 		} else if (options.excludeTerraDrawLayers === true) {
 			cloned.layers = cloned.layers.filter((l) => {
-				return 'source' in l && !sourceIds.includes(l.source);
+				return ('source' in l && !sourceIds.includes(l.source)) || l.type === 'background';
 			});
 			Object.keys(cloned.sources).forEach((key) => {
 				if (sourceIds.includes(key)) {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
