### PR TITLE
fix: add freehand-linestring to default modes of MaplibreMeasureControl.

### DIFF
--- a/.changeset/sour-crabs-grow.md
+++ b/.changeset/sour-crabs-grow.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: add freehand-linestring to default modes of MaplibreMeasureControl.

--- a/src/lib/constants/defaultMeasureControlOptions.ts
+++ b/src/lib/constants/defaultMeasureControlOptions.ts
@@ -28,6 +28,7 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 		'sector',
 		'circle',
 		'freehand',
+		'freehand-linestring',
 		'select',
 		'delete-selection',
 		'delete',


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

I forgot to add `freehand-linestring` mode to default modes of MeasureControl in previous PR.

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
