### PR TITLE
fix: fixed bug of not embedding valhalla_isochrone.svg in the output css file by deleting  maxSize setting in postcss.config.js

### DIFF
--- a/.changeset/afraid-areas-guess.md
+++ b/.changeset/afraid-areas-guess.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: fixed bug of not embedding valhalla_isochrone.svg in the output css file by deleting maxSize setting in postcss.config.js

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -6,8 +6,8 @@ export default {
 		postcssUrl({
 			url: 'inline',
 			filter: '**/*.svg',
-			optimizeSvgEncode: true,
-			maxSize: 14
+			optimizeSvgEncode: true
+			// maxSize: 14
 		}),
 		cssnano({
 			preset: 'default'

--- a/src/scss/maplibre-gl-terradraw.scss
+++ b/src/scss/maplibre-gl-terradraw.scss
@@ -380,7 +380,6 @@
 		}
 
 		th {
-			// background-color: #f8f9fa;
 			font-weight: 600;
 			font-size: 0.85rem;
 		}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #395 

`maxSize: 14` setting prevented to embed a SVG file in the file output file. I deleted the property, so all SVG will be included in the CSS

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
