### PR TITLE
feat: added forceDistanceUnit property in MaplibreMeasureControl to allow users to use the same distance unit always.

### DIFF
--- a/.changeset/calm-jeans-show.md
+++ b/.changeset/calm-jeans-show.md
@@ -1,0 +1,11 @@
+---
+'@watergis/maplibre-gl-terradraw': minor
+---
+
+feat: added forceDistanceUnit property in MaplibreMeasureControl to allow users to use the same distance unit always.
+
+- `forceDistanceUnit` parameter can accept from the following units:
+  - `auto`
+  - metric unit: `cm`, `m`, `km`
+
+Default is selected for auto which can convert metric distance unit automatically depending on a scale. If other unit type other than `kilometers` is set to `distanceUnit` property (for example, `miles`, `degrees`, `radian`), this `forceDistanceUnit` is ignored and cosidered as `auto`. In case, if you want to use other units other than metric, please use `distanceUnit` property instead.

--- a/.changeset/calm-jeans-show.md
+++ b/.changeset/calm-jeans-show.md
@@ -1,5 +1,5 @@
 ---
-'@watergis/maplibre-gl-terradraw': minor
+'@watergis/maplibre-gl-terradraw': patch
 ---
 
 feat: added forceDistanceUnit property in MaplibreMeasureControl to allow users to use the same distance unit always.

--- a/src/lib/constants/defaultMeasureControlOptions.ts
+++ b/src/lib/constants/defaultMeasureControlOptions.ts
@@ -398,6 +398,7 @@ export const defaultMeasureControlOptions: MeasureControlOptions = {
 	},
 	distanceUnit: 'kilometers',
 	distancePrecision: 2,
+	forceDistanceUnit: 'auto',
 	areaUnit: 'metric',
 	areaPrecision: 2,
 	forceAreaUnit: 'auto',

--- a/src/lib/controls/MaplibreMeasureControl.ts
+++ b/src/lib/controls/MaplibreMeasureControl.ts
@@ -13,6 +13,7 @@ import type {
 	AreaUnit,
 	DistanceUnit,
 	forceAreaUnitType,
+	forceDistanceUnitType,
 	MeasureControlOptions,
 	TerradrawMode
 } from '../interfaces';
@@ -61,6 +62,20 @@ export class MaplibreMeasureControl extends MaplibreTerradrawControl {
 	set distancePrecision(value: number) {
 		const isSame = this.measureOptions.distancePrecision === value;
 		this.measureOptions.distancePrecision = value;
+		if (!isSame) this.recalc();
+	}
+
+	/**
+	 * Default is `auto`. If `auto` is set, unit is converted depending on the value in metric. If a specific unit is specified, it returns the value always the same.
+	 * This property is only effective when distanceUnit is set to 'kilometers'. If distanceUnit is set to other than 'kilometers', it will be ignored, and `auto` will be applied.
+	 * If you need to force other unit type, please use DistanceUnit property.
+	 */
+	get forceDistanceUnit() {
+		return this.measureOptions.forceDistanceUnit ?? 'auto';
+	}
+	set forceDistanceUnit(value: forceDistanceUnitType) {
+		const isSame = this.measureOptions.forceDistanceUnit === value;
+		this.measureOptions.forceDistanceUnit = value;
 		if (!isSame) this.recalc();
 	}
 
@@ -846,6 +861,7 @@ export class MaplibreMeasureControl extends MaplibreTerradrawControl {
 					feature,
 					this.distanceUnit,
 					this.distancePrecision,
+					this.forceDistanceUnit,
 					this.map,
 					this.computeElevation,
 					this.measureOptions.terrainSource
@@ -1049,6 +1065,7 @@ export class MaplibreMeasureControl extends MaplibreTerradrawControl {
 					feature,
 					this.distanceUnit,
 					this.distancePrecision,
+					this.forceDistanceUnit,
 					this.map,
 					this.computeElevation,
 					this.measureOptions.terrainSource

--- a/src/lib/helpers/calcDistance.test.ts
+++ b/src/lib/helpers/calcDistance.test.ts
@@ -44,12 +44,12 @@ describe('calcDistance', () => {
 			properties: {}
 		};
 
-		const result = calcDistance(nonLineFeature, 'kilometers', 2);
+		const result = calcDistance(nonLineFeature, 'kilometers', 2, 'auto');
 		expect(result).toEqual(nonLineFeature);
 	});
 
 	it('should add distance, unit, and segments properties', () => {
-		const result = calcDistance(mockFeature, 'kilometers', 2);
+		const result = calcDistance(mockFeature, 'kilometers', 2, 'auto');
 		expect(result.properties).toHaveProperty('distance');
 		expect(result.properties).toHaveProperty('unit');
 		expect(result.properties).toHaveProperty('segments');
@@ -68,7 +68,7 @@ describe('calcDistance', () => {
 	});
 
 	it('should add elevation_start and elevation_end properties if computeElevation is true', () => {
-		const result = calcDistance(mockFeature, 'kilometers', 2, mockMap, true);
+		const result = calcDistance(mockFeature, 'kilometers', 2, 'auto', mockMap, true);
 		if (Array.isArray(result.properties.segments)) {
 			result.properties.segments.forEach((segment: unknown) => {
 				if (!segment || typeof segment !== 'object' || !('properties' in segment)) return;

--- a/src/lib/helpers/calcDistance.ts
+++ b/src/lib/helpers/calcDistance.ts
@@ -1,7 +1,7 @@
 import distance from '@turf/distance';
 import type { GeoJSONStoreFeatures } from 'terra-draw';
 import type { LngLatLike, Map } from 'maplibre-gl';
-import type { DistanceUnit, TerrainSource } from '../interfaces';
+import type { DistanceUnit, forceDistanceUnitType, TerrainSource } from '../interfaces';
 import { convertDistance } from './convertDistance';
 
 /**
@@ -9,6 +9,7 @@ import { convertDistance } from './convertDistance';
  * @param feature LineString GeoJSON feature
  * @param distanceUnit Distance unit
  * @param distancePrecision Precision of distance
+ * @param forceUnit Default is `auto`. If `auto` is set, unit is converted depending on the value in metric.
  * @param map Maplibre map instance
  * @param computeElevation Compute elevation for each segment
  * @param terrainSource Terrain source for elevation calculation. If terrainSource is undefined, going to to query elevation from maplibre terrain.
@@ -18,6 +19,7 @@ export const calcDistance = (
 	feature: GeoJSONStoreFeatures,
 	distanceUnit: DistanceUnit,
 	distancePrecision: number,
+	forceUnit?: forceDistanceUnitType,
 	map?: Map,
 	computeElevation?: boolean,
 	terrainSource?: TerrainSource
@@ -62,19 +64,28 @@ export const calcDistance = (
 	feature.properties.segments = JSON.parse(JSON.stringify(segments));
 
 	// convert distance unit
-	const convertedDistance = convertDistance(feature.properties.distance as number, distanceUnit);
+	const convertedDistance = convertDistance(
+		feature.properties.distance as number,
+		distanceUnit,
+		forceUnit
+	);
 	feature.properties.distance = convertedDistance.distance;
 	feature.properties.unit = convertedDistance.unit;
 
 	(feature.properties.segments as unknown as GeoJSONStoreFeatures[]).forEach(
 		(segment: GeoJSONStoreFeatures) => {
-			const segmentDistance = convertDistance(segment.properties.distance as number, distanceUnit);
+			const segmentDistance = convertDistance(
+				segment.properties.distance as number,
+				distanceUnit,
+				forceUnit
+			);
 			segment.properties.distance = segmentDistance.distance;
 			segment.properties.unit = segmentDistance.unit;
 
 			const segmentTotalDistance = convertDistance(
 				segment.properties.total as number,
-				distanceUnit
+				distanceUnit,
+				forceUnit
 			);
 			segment.properties.total = segmentTotalDistance.distance;
 			segment.properties.totalUnit = segmentTotalDistance.unit;

--- a/src/lib/helpers/convertDistance.test.ts
+++ b/src/lib/helpers/convertDistance.test.ts
@@ -1,31 +1,46 @@
 import { describe, it, expect } from 'vitest';
 import { convertDistance } from './convertDistance';
 
-describe('convertDistance with metric unit', () => {
+describe('convertDistance with metric unito', () => {
 	it('should return kilometers when distance is 1 or more', () => {
-		expect(convertDistance(1)).toEqual({ distance: 1, unit: 'km' });
-		expect(convertDistance(2.5)).toEqual({ distance: 2.5, unit: 'km' });
+		expect(convertDistance(1, 'kilometers', 'auto')).toEqual({ distance: 1, unit: 'km' });
+		expect(convertDistance(2.5, 'kilometers', 'auto')).toEqual({ distance: 2.5, unit: 'km' });
 	});
 
 	it('should return meters when distance is less than 1 km but 1 m or more', () => {
-		expect(convertDistance(0.5)).toEqual({ distance: 500, unit: 'm' });
-		expect(convertDistance(0.001)).toEqual({ distance: 1, unit: 'm' });
+		expect(convertDistance(0.5, 'kilometers', 'auto')).toEqual({ distance: 500, unit: 'm' });
+		expect(convertDistance(0.001, 'kilometers', 'auto')).toEqual({ distance: 1, unit: 'm' });
 	});
 
 	it('should return centimeters when distance is less than 1 meter', () => {
-		expect(convertDistance(0.0005)).toEqual({ distance: 50, unit: 'cm' });
-		expect(convertDistance(0.00001)).toEqual({ distance: 1, unit: 'cm' });
+		expect(convertDistance(0.0005, 'kilometers', 'auto')).toEqual({ distance: 50, unit: 'cm' });
+		expect(convertDistance(0.00001, 'kilometers', 'auto')).toEqual({ distance: 1, unit: 'cm' });
 	});
 
 	it('should handle edge case of 0 km', () => {
-		expect(convertDistance(0)).toEqual({ distance: 0, unit: 'cm' });
+		expect(convertDistance(0, 'kilometers', 'auto')).toEqual({ distance: 0, unit: 'cm' });
 	});
 
 	it('should handle floating point edge values accurately', () => {
-		expect(convertDistance(0.999)).toEqual({ distance: 999, unit: 'm' });
-		const result = convertDistance(0.000009);
+		expect(convertDistance(0.999, 'kilometers', 'auto')).toEqual({ distance: 999, unit: 'm' });
+		const result = convertDistance(0.000009, 'kilometers', 'auto');
 		expect(result.unit).toBe('cm');
 		expect(result.distance).toBeCloseTo(0.9, 5);
+	});
+
+	it('should return kilometers when forceDistanceUnit is kilometers', () => {
+		expect(convertDistance(1, 'kilometers', 'km')).toEqual({ distance: 1, unit: 'km' });
+		expect(convertDistance(2.5, 'kilometers', 'km')).toEqual({ distance: 2.5, unit: 'km' });
+	});
+
+	it('should return meters when forceDistanceUnit is meters', () => {
+		expect(convertDistance(1, 'kilometers', 'm')).toEqual({ distance: 1000, unit: 'm' });
+		expect(convertDistance(2.5, 'kilometers', 'm')).toEqual({ distance: 2500, unit: 'm' });
+	});
+
+	it('should return centimeters when forceDistanceUnit is centimeters', () => {
+		expect(convertDistance(1, 'kilometers', 'cm')).toEqual({ distance: 100000, unit: 'cm' });
+		expect(convertDistance(2.5, 'kilometers', 'cm')).toEqual({ distance: 250000, unit: 'cm' });
 	});
 });
 

--- a/src/lib/helpers/convertDistance.test.ts
+++ b/src/lib/helpers/convertDistance.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { convertDistance } from './convertDistance';
 
-describe('convertDistance with metric unito', () => {
+describe('convertDistance with metric unit', () => {
 	it('should return kilometers when distance is 1 or more', () => {
 		expect(convertDistance(1, 'kilometers', 'auto')).toEqual({ distance: 1, unit: 'km' });
 		expect(convertDistance(2.5, 'kilometers', 'auto')).toEqual({ distance: 2.5, unit: 'km' });

--- a/src/lib/interfaces/DistanceUnit.ts
+++ b/src/lib/interfaces/DistanceUnit.ts
@@ -7,15 +7,15 @@ export type DistanceUnit = 'degrees' | 'radians' | 'miles' | 'kilometers';
 /**
  * Short names for distance units in metric
  */
-export type MetricDitanceUnitShortName = 'km' | 'm' | 'cm';
+export type MetricDistanceUnitShortName = 'km' | 'm' | 'cm';
 
 /**
  * Short names for all distance units in metric, degrees, miles, and radians
  */
-export type DistanceUnitShortName = MetricDitanceUnitShortName | '°' | 'mi' | 'rad';
+export type DistanceUnitShortName = MetricDistanceUnitShortName | '°' | 'mi' | 'rad';
 
 /**
  * The type definition of forceDistanceUnitType
  * Currently only metric unit short names are supported. If you need other unit type, please use DistanceUnit property.
  */
-export type forceDistanceUnitType = 'auto' | MetricDitanceUnitShortName;
+export type forceDistanceUnitType = 'auto' | MetricDistanceUnitShortName;

--- a/src/lib/interfaces/DistanceUnit.ts
+++ b/src/lib/interfaces/DistanceUnit.ts
@@ -4,4 +4,18 @@
  */
 export type DistanceUnit = 'degrees' | 'radians' | 'miles' | 'kilometers';
 
-export type DistanceUnitShortName = 'km' | 'm' | 'cm' | '°' | 'mi' | 'rad';
+/**
+ * Short names for distance units in metric
+ */
+export type MetricDitanceUnitShortName = 'km' | 'm' | 'cm';
+
+/**
+ * Short names for all distance units in metric, degrees, miles, and radians
+ */
+export type DistanceUnitShortName = MetricDitanceUnitShortName | '°' | 'mi' | 'rad';
+
+/**
+ * The type definition of forceDistanceUnitType
+ * Currently only metric unit short names are supported. If you need other unit type, please use DistanceUnit property.
+ */
+export type forceDistanceUnitType = 'auto' | MetricDitanceUnitShortName;

--- a/src/lib/interfaces/MeasureControlOptions.ts
+++ b/src/lib/interfaces/MeasureControlOptions.ts
@@ -1,7 +1,7 @@
 import type { CircleLayerSpecification, SymbolLayerSpecification } from 'maplibre-gl';
 import type { ModeOptions } from './ModeOptions';
 import type { TerraDrawExtend } from 'terra-draw';
-import type { DistanceUnit } from './DistanceUnit';
+import type { DistanceUnit, forceDistanceUnitType } from './DistanceUnit';
 import type { AreaUnit, forceAreaUnitType } from './AreaUnit';
 import type { TerradrawMode } from './TerradrawMode';
 import type { TerrainSource } from './TerrainSource';
@@ -65,6 +65,13 @@ export interface MeasureControlOptions {
 	 * The precision of distance value. It will be set different value dwhen distance unit is changed. Using setter to override the value if you want.
 	 */
 	distancePrecision?: number;
+
+	/**
+	 * Default is `auto`. If `auto` is set, unit is converted depending on the value in metric. If a specific unit is specified, it returns the value always the same.
+	 * This property is only effective when distanceUnit is set to 'kilometers'. If distanceUnit is set to other than 'kilometers', it will be ignored, and `auto` will be applied.
+	 * If you need to force other unit type, please use DistanceUnit property.
+	 */
+	forceDistanceUnit?: forceDistanceUnitType;
 
 	/**
 	 * The unit of area can be metric (m², ha, km²) or imperial (acre, mi²). Default is metric

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@
 		type AreaUnit,
 		type DistanceUnit,
 		type forceAreaUnitType,
+		type forceDistanceUnitType,
 		type TerradrawMode,
 		type ValhallaOptions
 	} from '$lib';
@@ -37,6 +38,8 @@
 			JSON.parse(JSON.stringify(AvailableModes)),
 		distanceUnit: (page.url.searchParams.get('distanceUnit') as DistanceUnit) ?? 'kilometers',
 		distancePrecision: parseInt(page.url.searchParams.get('distancePrecision') ?? '2'),
+		forceDistanceUnit:
+			(page.url.searchParams.get('forceDistanceUnit') as forceDistanceUnitType) ?? 'auto',
 		areaUnit: (page.url.searchParams.get('areaUnit') as AreaUnit) ?? 'metric',
 		areaPrecision: parseInt(page.url.searchParams.get('areaPrecision') ?? '2'),
 		forceAreaUnit: (page.url.searchParams.get('forceAreaUnit') as forceAreaUnitType) ?? 'auto',
@@ -116,6 +119,7 @@
 		if (demoOptions.controlType == 'measure') {
 			pageUrl.searchParams.set('distanceUnit', demoOptions.distanceUnit);
 			pageUrl.searchParams.set('distancePrecision', demoOptions.distancePrecision.toString());
+			pageUrl.searchParams.set('forceDistanceUnit', demoOptions.forceDistanceUnit);
 			pageUrl.searchParams.set('areaUnit', demoOptions.areaUnit);
 			pageUrl.searchParams.set('areaPrecision', demoOptions.areaPrecision.toString());
 			pageUrl.searchParams.set('forceAreaUnit', demoOptions.forceAreaUnit);
@@ -123,6 +127,7 @@
 		} else {
 			pageUrl.searchParams.delete('distanceUnit');
 			pageUrl.searchParams.delete('distancePrecision');
+			pageUrl.searchParams.delete('forceDistanceUnit');
 			pageUrl.searchParams.delete('areaUnit');
 			pageUrl.searchParams.delete('areaPrecision');
 			pageUrl.searchParams.delete('forceAreaUnit');
@@ -145,6 +150,7 @@
 		const options = [];
 		options.push(`distanceUnit: '${demoOptions.distanceUnit}'`);
 		options.push(`distancePrecision: ${demoOptions.distancePrecision}`);
+		options.push(`forceDistanceUnit: '${demoOptions.forceDistanceUnit}'`);
 		options.push(`areaUnit: '${demoOptions.areaUnit}'`);
 		options.push(`areaPrecision: ${demoOptions.areaPrecision}`);
 		options.push(`forceAreaUnit: '${demoOptions.forceAreaUnit}'`);

--- a/src/routes/DemoMap.svelte
+++ b/src/routes/DemoMap.svelte
@@ -5,6 +5,7 @@
 		modes: TerradrawMode[];
 		distanceUnit: DistanceUnit;
 		distancePrecision: number;
+		forceDistanceUnit: forceDistanceUnitType;
 		areaUnit: AreaUnit;
 		areaPrecision: number;
 		forceAreaUnit: forceAreaUnitType;
@@ -30,6 +31,7 @@
 		type costingModelType,
 		type DistanceUnit,
 		type forceAreaUnitType,
+		type forceDistanceUnitType,
 		type routingDistanceUnitType,
 		type TerradrawMode,
 		type TerradrawValhallaMode,
@@ -70,6 +72,7 @@
 			modes: JSON.parse(JSON.stringify(AvailableModes)),
 			distanceUnit: 'kilometers',
 			distancePrecision: 2,
+			forceDistanceUnit: 'auto',
 			areaUnit: 'metric',
 			areaPrecision: 2,
 			forceAreaUnit: 'auto',
@@ -124,6 +127,7 @@
 		'area-unit',
 		'distance-precision',
 		'area-precision',
+		'force-distance-unit',
 		'force-area-unit',
 		'compute-elevation'
 	]);
@@ -560,6 +564,31 @@
 											</Segment.Item>
 										{/each}
 									</Segment>
+								{/snippet}
+							</Accordion.Item>
+
+							<Accordion.Item value="force-distance-unit">
+								{#snippet control()}
+									<p class="font-bold uppercase italic">Force Distance unit</p>
+								{/snippet}
+								{#snippet panel()}
+									<select
+										class="select"
+										value={options.forceDistanceUnit}
+										onchange={(e) => {
+											options.forceDistanceUnit = (e.target as HTMLSelectElement)
+												.value as forceDistanceUnitType;
+											if (drawControl && options.controlType === 'measure') {
+												(drawControl as MaplibreMeasureControl).forceDistanceUnit =
+													options.forceDistanceUnit;
+											}
+											onchange(options);
+										}}
+									>
+										{#each ['auto', 'km', 'm', 'cm'] as item (item)}
+											<option value={item}>{item}</option>
+										{/each}
+									</select>
 								{/snippet}
 							</Accordion.Item>
 


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fixes #405 

feat: added forceDistanceUnit property in MaplibreMeasureControl to allow users to use the same distance unit always.

- `forceDistanceUnit` parameter can accept from the following units:
  - `auto`
  - metric unit: `cm`, `m`, `km`

Default is selected for auto which can convert metric distance unit automatically depending on a scale. If other unit type other than `kilometers` is set to `distanceUnit` property (for example, `miles`, `degrees`, `radian`), this `forceDistanceUnit` is ignored and cosidered as `auto`. In case, if you want to use other units other than metric, please use `distanceUnit` property instead.

### Screenshots

- force `cm`

<img width="1822" height="1080" alt="image" src="https://github.com/user-attachments/assets/b9bc9cf0-8071-4678-a142-f99927f01e0b" />

- force `m`

<img width="1817" height="658" alt="image" src="https://github.com/user-attachments/assets/f32c37e7-97a3-4c6b-9a0b-a5845fbd7e6f" />

- force 'km`

<img width="1785" height="719" alt="image" src="https://github.com/user-attachments/assets/30935073-f768-4f07-b19c-2a627d1bb1ac" />

- auto

<img width="1738" height="568" alt="image" src="https://github.com/user-attachments/assets/960dc5bf-648b-4e82-a3e6-c26c3f1bedcd" />


## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [x] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
