### PR TITLE
fix: make sure passing measureUnitSymbols to helper functions

### DIFF
--- a/.changeset/lovely-terms-yawn.md
+++ b/.changeset/lovely-terms-yawn.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: make sure passing measureUnitSymbols to helper functions

--- a/src/lib/helpers/calcArea.ts
+++ b/src/lib/helpers/calcArea.ts
@@ -13,6 +13,7 @@ import { convertAreaUnit } from './convertAreaUnit';
  * @param unitType measure unit type either metric or imperial
  * @param areaPrecision Precision of area value
  * @param forceUnit Default is `auto`. If `auto` is set, unit is converted depending on the value and selection of area unit. If a specific unit is specified, it returns the value always the same. If a selected unit is not the same type of unit either metric of imperial, it will be ignored, and `auto` will be applied.
+ * @param measureUnitSymbols Optional parameter to provide custom unit symbols
  * @returns  The returning feature will contain `area`,`unit` properties.
  */
 export const calcArea = (
@@ -20,13 +21,13 @@ export const calcArea = (
 	unitType: MeasureUnitType,
 	areaPrecision: number,
 	forceUnit?: forceAreaUnitType,
-	measyreUnitSymbols?: MeasureUnitSymbolType
+	measureUnitSymbols?: MeasureUnitSymbolType
 ) => {
 	if (feature.geometry.type !== 'Polygon') return feature;
 	// caculate area in m2 by using turf/area
 	const result = area(feature.geometry);
 
-	const converted = convertAreaUnit(result, unitType, forceUnit, measyreUnitSymbols);
+	const converted = convertAreaUnit(result, unitType, forceUnit, measureUnitSymbols);
 	converted.area = parseFloat(converted.area.toFixed(areaPrecision));
 
 	feature.properties.area = converted.area;

--- a/src/lib/helpers/calcDistance.ts
+++ b/src/lib/helpers/calcDistance.ts
@@ -74,7 +74,8 @@ export const calcDistance = (
 	const convertedDistance = convertDistance(
 		feature.properties.distance as number,
 		unitType,
-		forceUnit
+		forceUnit,
+		measureUnitSymbols
 	);
 	feature.properties.distance = convertedDistance.distance;
 	feature.properties.unit = convertedDistance.unit;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

forgot to pass measureUnitSymbols to some helper functions

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
