### PR TITLE
chore: show vitest coverage on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
   vitest-test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         node-version: [22]
@@ -74,6 +77,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run vitest
         run: pnpm test:vitest:coverage
+      - name: Report Coverage
+        uses: davelosert/vitest-coverage-report-action@v2
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 		coverage: {
 			include: ['src/lib/**/*.{js,ts}'],
 			exclude: ['src/lib/**/index.{js,ts}', 'src/lib/interfaces/**/*.{js,ts}'],
-			reporter: ['text', 'json', 'html']
+			reporter: ['text', 'json-summary', 'json', 'html']
 		}
 	}
 });


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

trying to use davelosert/vitest-coverage-report-action to show vitest result on PR

## What this PR is going to change for

Select items related to this PR.

- [ ] maplibre-gl-terradraw
- [ ] documentation
- [x] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documentation
- [x] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [ ] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
