### PR TITLE
chore: bump version to v1.9.5

### DIFF
--- a/.changeset/shiny-cameras-prove.md
+++ b/.changeset/shiny-cameras-prove.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+chore: re-rerelease the version due to issue #471


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

after `pnpm build`, my local VSCode looks ok for dist folder.

<img width="410" height="381" alt="image" src="https://github.com/user-attachments/assets/51eb9b38-1a24-46aa-843d-33af9a3b7192" />

however, v1.9.4 has weird types folder. all code is under types/lib folder which causes issue #471. let me try bump a version again if this can correct dist folder

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
