### PR TITLE
docs: fixed the light/dark mode theme toggle and text on dark mode

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,6 +6,27 @@
 
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
+
+		<script>
+			(function () {
+				try {
+					var stored = localStorage.getItem('light-dark-mode');
+					var prefersDark;
+
+					if (stored) {
+						prefersDark = stored === 'dark';
+					} else {
+						prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+						localStorage.setItem('light-dark-mode', prefersDark ? 'dark' : 'light');
+					}
+
+					document.documentElement.setAttribute('data-mode', prefersDark ? 'dark' : 'light');
+				} catch (e) {
+					var fallback = window.matchMedia('(prefers-color-scheme: dark)').matches;
+					document.documentElement.setAttribute('data-mode', fallback ? 'dark' : 'light');
+				}
+			})();
+		</script>
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/src/routes/DemoMap.svelte
+++ b/src/routes/DemoMap.svelte
@@ -690,7 +690,7 @@
 					</Accordion.ItemTrigger>
 					<Accordion.ItemContent>
 						<div class="p-2">
-							<p class="text-black">
+							<p>
 								For Polygon, use <b>ctrl+s</b> to resize the feature, and use <b>ctrl+r</b> to rotate
 								the feature.
 							</p>

--- a/src/routes/LightSwitch.svelte
+++ b/src/routes/LightSwitch.svelte
@@ -2,20 +2,20 @@
 	import IconMoon from '@lucide/svelte/icons/moon';
 	import IconSun from '@lucide/svelte/icons/sun';
 
-	let checked = $state(false);
+	let isDark = $state(false);
 
 	const localStorageKey = 'light-dark-mode';
 
 	$effect(() => {
-		const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-		checked = prefersDark === true;
+		const prefersDark = localStorage.getItem(localStorageKey) === 'dark';
+		isDark = prefersDark === true;
 	});
 
-	const onCheckedChange = (event: { checked: boolean }) => {
-		const mode = event.checked ? 'dark' : 'light';
+	const onCheckedChange = (event: { isDark: boolean }) => {
+		const mode = event.isDark ? 'dark' : 'light';
 		document.documentElement.setAttribute('data-mode', mode);
 		localStorage.setItem(localStorageKey, mode);
-		checked = event.checked;
+		isDark = event.isDark;
 	};
 </script>
 
@@ -23,12 +23,12 @@
 	type="button"
 	class="btn hover:preset-tonal px-1 md:px-2"
 	onclick={() => {
-		checked = !checked;
-		onCheckedChange({ checked });
+		isDark = !isDark;
+		onCheckedChange({ isDark });
 	}}
 >
 	<span>
-		{#if checked}
+		{#if isDark}
 			<IconMoon />
 		{:else}
 			<IconSun />


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Fixed theme toggling in the main documentation page. Theme not persisting with page reloads and also not applying the system preferences. 

Also fixed the paragraph text above the feature properties code block, it's black in dark mode hence not clearly visible.

## What this PR is going to change for

Select items related to this PR.

- [ ] maplibre-gl-terradraw
- [x] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [x] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [ ] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
