### PR TITLE
feat: make TextMode label font configurable.

### DIFF
--- a/.changeset/text-mode-configurable-font.md
+++ b/.changeset/text-mode-configurable-font.md
@@ -2,4 +2,8 @@
 '@watergis/maplibre-gl-terradraw': patch
 ---
 
-feat: make TextMode label font configurable via `TextModeStyling.textFont`. Defaults to `['sans-serif']` so labels are not constrained by the map style's available glyphs.
+feat: make TextMode label font configurable.
+
+Set it declaratively via `TextModeStyling.textFont`, or at runtime via the new `fontGlyphs` property on `MaplibreTerradrawControl`.
+
+Defaults to `['sans-serif']` so labels are not constrained by the map style's available glyphs. `MaplibreMeasureControl` / `MaplibreValhallaControl` now reuse this base `fontGlyphs` implementation, so setting their `fontGlyphs` also updates the TextMode label font.

--- a/.changeset/text-mode-configurable-font.md
+++ b/.changeset/text-mode-configurable-font.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+feat: make TextMode label font configurable via `TextModeStyling.textFont`. Defaults to `['sans-serif']` so labels are not constrained by the map style's available glyphs.

--- a/src/lib/controls/MaplibreMeasureControl.ts
+++ b/src/lib/controls/MaplibreMeasureControl.ts
@@ -221,20 +221,13 @@ export class MaplibreMeasureControl extends MaplibreTerradrawControl {
 	}
 
 	set fontGlyphs(fontNames: string[]) {
-		const layers = [
+		// also apply to the TextMode label layer via the base implementation
+		super.fontGlyphs = fontNames;
+		this.applyFontGlyphs(fontNames, [
 			this.measureOptions.pointLayerLabelSpec,
 			this.measureOptions.lineLayerLabelSpec,
 			this.measureOptions.polygonLayerSpec
-		];
-		for (const layer of layers) {
-			if (layer && layer.layout) {
-				layer.layout['text-font'] = fontNames;
-			}
-			// layer exists in maplibre, update glyphs as well
-			if (this.map && layer && this.map.getLayer(layer.id)) {
-				this.map.setLayoutProperty(layer.id, 'text-font', fontNames);
-			}
-		}
+		]);
 	}
 
 	/**

--- a/src/lib/controls/MaplibreTerradrawControl.test.ts
+++ b/src/lib/controls/MaplibreTerradrawControl.test.ts
@@ -2059,6 +2059,35 @@ describe('text layer methods', () => {
 			);
 		});
 
+		it('uses the default sans-serif text-font when no textFont style is set', () => {
+			const control = new MaplibreTerradrawControl({ modes: ['text'] });
+			control.onAdd(mockMap);
+
+			expect(mockMap.addLayer).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: 'td-text-labels',
+					layout: expect.objectContaining({ 'text-font': ['sans-serif'] })
+				})
+			);
+		});
+
+		it('uses the textFont style when provided in modeOptions', () => {
+			const control = new MaplibreTerradrawControl({
+				modes: ['text'],
+				modeOptions: {
+					text: new TerraDrawTextMode({ styles: { textFont: ['Noto Sans Regular'] } })
+				}
+			});
+			control.onAdd(mockMap);
+
+			expect(mockMap.addLayer).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: 'td-text-labels',
+					layout: expect.objectContaining({ 'text-font': ['Noto Sans Regular'] })
+				})
+			);
+		});
+
 		it('calls moveLayer to bring text labels to the top', () => {
 			const control = new MaplibreTerradrawControl({ modes: ['text'] });
 			control.onAdd(mockMap);

--- a/src/lib/controls/MaplibreTerradrawControl.test.ts
+++ b/src/lib/controls/MaplibreTerradrawControl.test.ts
@@ -2088,6 +2088,24 @@ describe('text layer methods', () => {
 			);
 		});
 
+		it('uses the fontGlyphs property over the textFont style when both are set', () => {
+			const control = new MaplibreTerradrawControl({
+				modes: ['text'],
+				modeOptions: {
+					text: new TerraDrawTextMode({ styles: { textFont: ['Noto Sans Regular'] } })
+				}
+			});
+			control.fontGlyphs = ['Open Sans Italic'];
+			control.onAdd(mockMap);
+
+			expect(mockMap.addLayer).toHaveBeenCalledWith(
+				expect.objectContaining({
+					id: 'td-text-labels',
+					layout: expect.objectContaining({ 'text-font': ['Open Sans Italic'] })
+				})
+			);
+		});
+
 		it('calls moveLayer to bring text labels to the top', () => {
 			const control = new MaplibreTerradrawControl({ modes: ['text'] });
 			control.onAdd(mockMap);
@@ -2142,6 +2160,42 @@ describe('text layer methods', () => {
 			);
 			const call = mockSetData.mock.calls[0][0];
 			expect(call.features).toHaveLength(1);
+		});
+	});
+
+	describe('fontGlyphs property', () => {
+		it('returns undefined when not set', () => {
+			const control = new MaplibreTerradrawControl({ modes: ['text'] });
+			expect(control.fontGlyphs).toBeUndefined();
+		});
+
+		it('stores the assigned font glyphs on the getter', () => {
+			const control = new MaplibreTerradrawControl({ modes: ['text'] });
+			control.fontGlyphs = ['Open Sans Italic'];
+			expect(control.fontGlyphs).toEqual(['Open Sans Italic']);
+		});
+
+		it('updates the text-labels layer when it already exists on the map', () => {
+			const control = new MaplibreTerradrawControl({ modes: ['text'] });
+			control.onAdd(mockMap);
+			vi.mocked(mockMap.getLayer).mockReturnValue({ id: 'td-text-labels' } as never);
+
+			control.fontGlyphs = ['Open Sans Italic'];
+
+			expect(mockMap.setLayoutProperty).toHaveBeenCalledWith('td-text-labels', 'text-font', [
+				'Open Sans Italic'
+			]);
+		});
+
+		it('does not call setLayoutProperty when the text-labels layer does not exist', () => {
+			const control = new MaplibreTerradrawControl({ modes: ['text'] });
+			control.onAdd(mockMap);
+			vi.mocked(mockMap.getLayer).mockReturnValue(undefined as never);
+			vi.mocked(mockMap.setLayoutProperty).mockClear();
+
+			control.fontGlyphs = ['Open Sans Italic'];
+
+			expect(mockMap.setLayoutProperty).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/lib/controls/MaplibreTerradrawControl.ts
+++ b/src/lib/controls/MaplibreTerradrawControl.ts
@@ -899,7 +899,7 @@ export class MaplibreTerradrawControl implements IControl {
 	protected addTextFeaturesToSource(
 		features: GeoJSONStoreFeatures<GeoJSONStoreGeometries>[],
 		map: Map,
-		styles?: Record<string, string | number>
+		styles?: TextModeStyling
 	) {
 		const prefixId = this.options.adapterOptions?.prefixId ?? 'td';
 
@@ -925,7 +925,7 @@ export class MaplibreTerradrawControl implements IControl {
 					'text-size': (styles?.textSize as number) ?? 12,
 					'text-anchor': 'top',
 					'text-offset': [0, 0.8],
-					'text-font': ['Noto Sans Regular'],
+					'text-font': styles?.textFont ?? ['sans-serif'],
 					'text-allow-overlap': true
 				},
 				paint: {

--- a/src/lib/controls/MaplibreTerradrawControl.ts
+++ b/src/lib/controls/MaplibreTerradrawControl.ts
@@ -4,7 +4,8 @@ import type {
 	GeoJSONSourceSpecification,
 	IControl,
 	Map,
-	StyleSpecification
+	StyleSpecification,
+	SymbolLayerSpecification
 } from 'maplibre-gl';
 import {
 	TerraDraw,
@@ -37,12 +38,72 @@ export class MaplibreTerradrawControl implements IControl {
 	protected modeButtons: { [key: string]: HTMLButtonElement } = {};
 	protected _isExpanded = false;
 	protected _cssPrefix = '';
+	protected _fontGlyphs?: string[];
 
 	/**
 	 * get the state of whether the control is expanded or collapsed
 	 */
 	public get isExpanded(): boolean {
 		return this._isExpanded;
+	}
+
+	/**
+	 * Get/Set font glyph for the TextMode label layer (`{prefix}-text-labels`).
+	 *
+	 * As default, the TextMode label uses `sans-serif` so it is not constrained by the
+	 * glyphs available in your maplibre style. See https://maplibre.org/maplibre-style-spec/layers/#text-font
+	 *
+	 * If you are using your own maplibre style or a different map provider, you probably need to set the
+	 * font glyphs to match glyphs available in your maplibre style.
+	 *
+	 * Font glyph availability depends on what types of glyphs are supported by your maplibre style
+	 * (e.g., Carto, Openmap tiles, Protomap, Maptiler, etc.). Please make sure the font glyphs are
+	 * available in your maplibre style.
+	 *
+	 * Usage:
+	 *
+	 * ```js
+	 * const drawControl = new MaplibreTerradrawControl({ modes: ['text'] })
+	 * drawControl.fontGlyphs = ['Open Sans Italic']
+	 * map.addControl(drawControl)
+	 * ```
+	 */
+	public get fontGlyphs(): string[] | undefined {
+		return this._fontGlyphs;
+	}
+
+	public set fontGlyphs(fontNames: string[]) {
+		this._fontGlyphs = fontNames;
+		// update the TextMode label layer if it already exists on the map
+		const prefixId = this.options.adapterOptions?.prefixId ?? 'td';
+		const layerId = `${prefixId}-text-labels`;
+		if (this.map && this.map.getLayer(layerId)) {
+			this.map.setLayoutProperty(layerId, 'text-font', fontNames);
+		}
+	}
+
+	/**
+	 * Apply the given font glyphs to the provided symbol layer specs and, when they already
+	 * exist on the map, to their live layers via `setLayoutProperty`.
+	 *
+	 * Shared by subclasses (e.g. `MaplibreMeasureControl`, `MaplibreValhallaControl`) so their
+	 * `fontGlyphs` setters can reuse the same layer-update logic.
+	 * @param fontNames font glyph names to apply as `text-font`
+	 * @param layers symbol layer specs to update (undefined entries are skipped)
+	 */
+	protected applyFontGlyphs(
+		fontNames: string[],
+		layers: (SymbolLayerSpecification | undefined)[]
+	): void {
+		for (const layer of layers) {
+			if (layer && layer.layout) {
+				layer.layout['text-font'] = fontNames;
+			}
+			// layer exists in maplibre, update glyphs as well
+			if (this.map && layer && this.map.getLayer(layer.id)) {
+				this.map.setLayoutProperty(layer.id, 'text-font', fontNames);
+			}
+		}
 	}
 
 	/**
@@ -925,7 +986,7 @@ export class MaplibreTerradrawControl implements IControl {
 					'text-size': (styles?.textSize as number) ?? 12,
 					'text-anchor': 'top',
 					'text-offset': [0, 0.8],
-					'text-font': styles?.textFont ?? ['sans-serif'],
+					'text-font': this._fontGlyphs ?? styles?.textFont ?? ['sans-serif'],
 					'text-allow-overlap': true
 				},
 				paint: {

--- a/src/lib/controls/MaplibreValhallaControl.ts
+++ b/src/lib/controls/MaplibreValhallaControl.ts
@@ -187,16 +187,9 @@ export class MaplibreValhallaControl extends MaplibreTerradrawControl {
 	}
 
 	set fontGlyphs(fontNames: string[]) {
-		const layers = [this.controlOptions.routingLineLayerNodeLabelSpec];
-		for (const layer of layers) {
-			if (layer && layer.layout) {
-				layer.layout['text-font'] = fontNames;
-			}
-			// layer exists in maplibre, update glyphs as well
-			if (this.map && layer && this.map.getLayer(layer.id)) {
-				this.map.setLayoutProperty(layer.id, 'text-font', fontNames);
-			}
-		}
+		// also apply to the TextMode label layer via the base implementation
+		super.fontGlyphs = fontNames;
+		this.applyFontGlyphs(fontNames, [this.controlOptions.routingLineLayerNodeLabelSpec]);
 	}
 
 	/**

--- a/src/lib/modes/TerraDrawTextMode.ts
+++ b/src/lib/modes/TerraDrawTextMode.ts
@@ -55,6 +55,14 @@ export type TextModeStyling = {
 	textSelectedHaloColor?: HexColor;
 	/** MapLibre `text-halo-width` paint property in pixels. Default `5`. */
 	textHaloWidth?: number;
+	/**
+	 * MapLibre `text-font` layout property (font stack). Default `['sans-serif']`.
+	 *
+	 * The default `sans-serif` is used so labels are not constrained by the
+	 * glyphs available in the map style. Set this to a font that exists in your
+	 * style's glyphs (e.g. `['Noto Sans Regular']`) to change the label font.
+	 */
+	textFont?: string[];
 };
 
 /**
@@ -175,7 +183,11 @@ export type TextModeOptions = {
  * map.addControl(control, 'top-right');
  * ```
  */
-export class TerraDrawTextMode extends TerraDrawBaseDrawMode<TextModeStyling> {
+// `textFont` is a MapLibre symbol-layer concern consumed by `MaplibreTerradrawControl`,
+// not by Terra Draw's `styleFeature`. It is a `string[]`, which does not satisfy Terra Draw's
+// `CustomStyling` value constraint, so it is omitted from the base-class generic while still
+// remaining part of the public `TextModeStyling` / `options.styles` merge path.
+export class TerraDrawTextMode extends TerraDrawBaseDrawMode<Omit<TextModeStyling, 'textFont'>> {
 	mode = 'text';
 
 	options?: TextModeOptions;

--- a/src/routes/DemoMap.svelte
+++ b/src/routes/DemoMap.svelte
@@ -202,8 +202,6 @@
 					prefixId: 'td-measure'
 				}
 			});
-			(drawControl as MaplibreMeasureControl).fontGlyphs = ['Noto Sans Medium'];
-			map.addControl(drawControl, 'top-left');
 		} else if (options.controlType === 'valhalla') {
 			const modes = options.modes.filter((mode) =>
 				AvailableValhallaModes.includes(mode as (typeof AvailableValhallaModes)[number])
@@ -218,8 +216,6 @@
 				},
 				valhallaOptions: options.valhallaOptions
 			});
-			(drawControl as MaplibreValhallaControl).fontGlyphs = ['Noto Sans Medium'];
-			map.addControl(drawControl, 'top-left');
 		} else {
 			drawControl = new MaplibreTerradrawControl({
 				modes: options.modes,
@@ -230,8 +226,9 @@
 					prefixId: 'td-default'
 				}
 			});
-			map.addControl(drawControl, 'top-left');
 		}
+		drawControl.fontGlyphs = ['Noto Sans Medium'];
+		map.addControl(drawControl, 'top-left');
 
 		const drawInstance = drawControl.getTerraDrawInstance();
 		drawInstance?.on('select', (id: string | number) => {


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Set it declaratively via `TextModeStyling.textFont`, or at runtime via the new `fontGlyphs` property on `MaplibreTerradrawControl`.

Defaults to `['sans-serif']` so labels are not constrained by the map style's available glyphs. `MaplibreMeasureControl` / `MaplibreValhallaControl` now reuse this base `fontGlyphs` implementation, so setting their `fontGlyphs` also updates the TextMode label font.

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
