### PR TITLE
fix: check existence of text mode layers before deleting all features

### DIFF
--- a/.changeset/guard-clear-text-layers.md
+++ b/.changeset/guard-clear-text-layers.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': minor
+---
+
+fix: only remove the text mode layer and source when a text mode layer exists to avoid errors when deleting all features without a text layer

--- a/.changeset/guard-clear-text-layers.md
+++ b/.changeset/guard-clear-text-layers.md
@@ -1,5 +1,5 @@
 ---
-'@watergis/maplibre-gl-terradraw': minor
+'@watergis/maplibre-gl-terradraw': patch
 ---
 
 fix: only remove the text mode layer and source when a text mode layer exists to avoid errors when deleting all features without a text layer

--- a/src/lib/controls/MaplibreTerradrawControl.test.ts
+++ b/src/lib/controls/MaplibreTerradrawControl.test.ts
@@ -2391,7 +2391,7 @@ describe('text layer methods', () => {
 	});
 
 	describe('clearTextLayers', () => {
-		it('removes the text layer and source', () => {
+		it('removes the text layer and source only', () => {
 			const control = new MaplibreTerradrawControl({ modes: ['text'] });
 			control.onAdd(mockMap);
 
@@ -2405,6 +2405,26 @@ describe('text layer methods', () => {
 
 			expect(mockMap.removeLayer).toHaveBeenCalledWith('td-text-labels');
 			expect(mockMap.removeSource).toHaveBeenCalledWith('td-text');
+		});
+
+		it('does not remove any layer or source when the text-labels layer does not exist', () => {
+			const control = new MaplibreTerradrawControl({ modes: ['text'] });
+			control.onAdd(mockMap);
+
+			vi.mocked(mockMap.removeLayer).mockClear();
+			vi.mocked(mockMap.removeSource).mockClear();
+
+			// no text-labels layer is present on the map
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(mockMap as any).style = { getLayer: vi.fn().mockReturnValue(undefined) };
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(mockMap as any).getSource = vi.fn().mockReturnValue(undefined);
+
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			expect(() => (control as any).clearTextLayers()).not.toThrow();
+
+			expect(mockMap.removeLayer).not.toHaveBeenCalled();
+			expect(mockMap.removeSource).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/lib/controls/MaplibreTerradrawControl.ts
+++ b/src/lib/controls/MaplibreTerradrawControl.ts
@@ -1122,7 +1122,9 @@ export class MaplibreTerradrawControl implements IControl {
 		const source = this.map?.getSource(`${prefixId}-text`) as maplibregl.GeoJSONSource | undefined;
 		const layers = this.map?.style?.getLayer(`${prefixId}-text-labels`);
 
-		this.map?.removeLayer(layers?.id as string);
-		this.map?.removeSource(source?.id as string);
+		if (layers) {
+			this.map?.removeLayer(layers?.id as string);
+			this.map?.removeSource(source?.id as string);
+		}
 	}
 }


### PR DESCRIPTION
test: added tests for deleting text layers and source only when they exist

Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()

<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`

<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
