### PR TITLE
fix: Set 0,0 for text-offset and center for text-anchor to show label at exact position users clicked.

### DIFF
--- a/.changeset/open-results-deny.md
+++ b/.changeset/open-results-deny.md
@@ -1,0 +1,5 @@
+---
+'@watergis/maplibre-gl-terradraw': patch
+---
+
+fix: previously text label was shown slightly south of user inputed coordinates. Set 0,0 for text-offset and center for text-anchor to show label at exact position users clicked.

--- a/src/lib/controls/MaplibreTerradrawControl.ts
+++ b/src/lib/controls/MaplibreTerradrawControl.ts
@@ -998,8 +998,8 @@ export class MaplibreTerradrawControl implements IControl {
 				layout: {
 					'text-field': ['get', 'text'],
 					'text-size': (styles?.textSize as number) ?? 12,
-					'text-anchor': 'top',
-					'text-offset': [0, 0.8],
+					'text-anchor': 'center',
+					'text-offset': [0, 0],
 					'text-font': this._fontGlyphs ?? styles?.textFont ?? ['sans-serif'],
 					'text-allow-overlap': true
 				},


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

fix: previously text label was shown slightly south of user inputed coordinates. Set 0,0 for text-offset and center for text-anchor to show label at exact position users clicked.

## What this PR is going to change for

Select items related to this PR.

- [x] maplibre-gl-terradraw
- [ ] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documentation
- [ ] Others ()

<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [x] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`

<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
