### PR TITLE
refactor: improved UX of the Theme Switcher Button

### DIFF
--- a/src/routes/LightSwitch.svelte
+++ b/src/routes/LightSwitch.svelte
@@ -26,12 +26,13 @@
 		isDark = !isDark;
 		onCheckedChange({ isDark });
 	}}
+	title="Switch to {isDark ? 'Light' : 'Dark'} Mode"
 >
 	<span>
 		{#if isDark}
-			<IconMoon />
-		{:else}
 			<IconSun />
+		{:else}
+			<IconMoon />
 		{/if}
 	</span>
 </button>


### PR DESCRIPTION

Thank you for submitting a pull request!

## Description

Added button tooltip to the theme switcher and reversed icon visibility. i.e on Dark theme, the icon visible is the Sun icon and on Light theme, the visible icon is the Moon Icon; for better UX.

## What this PR is going to change for

Select items related to this PR.

- [ ] maplibre-gl-terradraw
- [x] documentation
- [ ] others

## Type of Pull Request

<!-- ignore-task-list-start -->

- [ ] Adding a feature
- [ ] Fixing a bug
- [x] Maintaining documentation
- [ ] Others ()

<!-- ignore-task-list-end -->

## Verify the followings

<!-- ignore-task-list-start -->

- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] All tests passes with `pnpm test`
- [x] Make sure all the existing features working well
- [ ] Make sure a changeset file is added if your PR changes package code by `pnpm changeset`

<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-terradraw/tree/main/CONTRIBUTING.md) for more details.
